### PR TITLE
Return more specific types than IConfigurable

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBlockConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBlockConfig.java
@@ -33,7 +33,7 @@ public class BlockCrystalizedChorusBlockConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlock initSubInstance() {
         ConfigurableBlock block = (ConfigurableBlock) new ConfigurableBlock(this, Material.CLAY) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBlockStairsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBlockStairsConfig.java
@@ -32,7 +32,7 @@ public class BlockCrystalizedChorusBlockStairsConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockStairs initSubInstance() {
         ConfigurableBlockStairs block = (ConfigurableBlockStairs) new ConfigurableBlockStairs(this, BlockMenrilLog.getInstance().getDefaultState()) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBrickConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBrickConfig.java
@@ -33,7 +33,7 @@ public class BlockCrystalizedChorusBrickConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlock initSubInstance() {
         ConfigurableBlock block = (ConfigurableBlock) new ConfigurableBlock(this, Material.CLAY) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBrickStairsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedChorusBrickStairsConfig.java
@@ -32,7 +32,7 @@ public class BlockCrystalizedChorusBrickStairsConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockStairs initSubInstance() {
         ConfigurableBlockStairs block = (ConfigurableBlockStairs) new ConfigurableBlockStairs(this, BlockMenrilLog.getInstance().getDefaultState()) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBlockConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBlockConfig.java
@@ -33,7 +33,7 @@ public class BlockCrystalizedMenrilBlockConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlock initSubInstance() {
         ConfigurableBlock block = (ConfigurableBlock) new ConfigurableBlock(this, Material.CLAY) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBlockStairsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBlockStairsConfig.java
@@ -32,7 +32,7 @@ public class BlockCrystalizedMenrilBlockStairsConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockStairs initSubInstance() {
         ConfigurableBlockStairs block = (ConfigurableBlockStairs) new ConfigurableBlockStairs(this, BlockMenrilLog.getInstance().getDefaultState()) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBrickConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBrickConfig.java
@@ -33,7 +33,7 @@ public class BlockCrystalizedMenrilBrickConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlock initSubInstance() {
         ConfigurableBlock block = (ConfigurableBlock) new ConfigurableBlock(this, Material.CLAY) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBrickStairsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCrystalizedMenrilBrickStairsConfig.java
@@ -32,7 +32,7 @@ public class BlockCrystalizedMenrilBrickStairsConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockStairs initSubInstance() {
         ConfigurableBlockStairs block = (ConfigurableBlockStairs) new ConfigurableBlockStairs(this, BlockMenrilLog.getInstance().getDefaultState()) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilLeavesConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilLeavesConfig.java
@@ -54,7 +54,7 @@ public class BlockMenrilLeavesConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockLeaves initSubInstance() {
         return (ConfigurableBlockLeaves) new ConfigurableBlockLeaves(this) {
             @Override
             public Item getItemDropped(IBlockState iBlockState, Random random, int i) {

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilPlanksConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilPlanksConfig.java
@@ -35,7 +35,7 @@ public class BlockMenrilPlanksConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlock initSubInstance() {
         return (ConfigurableBlock) new ConfigurableBlock(this, Material.WOOD) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilPlanksStairsConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilPlanksStairsConfig.java
@@ -34,7 +34,7 @@ public class BlockMenrilPlanksStairsConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockStairs initSubInstance() {
         return (ConfigurableBlockStairs) new ConfigurableBlockStairs(this, BlockMenrilLog.getInstance().getDefaultState()) {
             @SuppressWarnings("deprecation")
             @Override

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilSaplingConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilSaplingConfig.java
@@ -41,7 +41,7 @@ public class BlockMenrilSaplingConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockSapling initSubInstance() {
         return new ConfigurableBlockSapling(this, Material.PLANTS, new WorldGeneratorMenrilTree(false));
     }
     

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilTorchConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilTorchConfig.java
@@ -37,7 +37,7 @@ public class BlockMenrilTorchConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockTorch initSubInstance() {
         return new ConfigurableBlockTorch(this) {
             @Override
             public void randomDisplayTick(IBlockState state, World worldIn, BlockPos pos, Random rand) {

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilTorchStoneConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockMenrilTorchStoneConfig.java
@@ -39,7 +39,7 @@ public class BlockMenrilTorchStoneConfig extends BlockConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableBlockTorch initSubInstance() {
         return new ConfigurableBlockTorch(this) {
             @Override
             public void randomDisplayTick(IBlockState state, World worldIn, BlockPos pos, Random rand) {

--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemCrystalizedChorusChunkConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemCrystalizedChorusChunkConfig.java
@@ -31,7 +31,7 @@ public class ItemCrystalizedChorusChunkConfig extends ItemConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableItem initSubInstance() {
         return new ConfigurableItem(this);
     }
     

--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemCrystalizedMenrilChunkConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemCrystalizedMenrilChunkConfig.java
@@ -31,7 +31,7 @@ public class ItemCrystalizedMenrilChunkConfig extends ItemConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableItem initSubInstance() {
         return new ConfigurableItem(this);
     }
     

--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemLogicDirectorConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemLogicDirectorConfig.java
@@ -31,7 +31,7 @@ public class ItemLogicDirectorConfig extends ItemConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableItem initSubInstance() {
         return new ConfigurableItem(this);
     }
     

--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemMenrilBerriesConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemMenrilBerriesConfig.java
@@ -42,7 +42,7 @@ public class ItemMenrilBerriesConfig extends ItemConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
+    protected ConfigurableItemFood initSubInstance() {
         ConfigurableItemFood food = new ConfigurableItemFood(this, 4, 0.3F, false) {
             @Override
             public int getMaxItemUseDuration(ItemStack stack) {

--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemVariableTransformerConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemVariableTransformerConfig.java
@@ -35,8 +35,8 @@ public class ItemVariableTransformerConfig extends ItemConfig {
     }
 
     @Override
-    protected IConfigurable initSubInstance() {
-        return (IConfigurable) new ConfigurableItem(this) {
+    protected ConfigurableItem initSubInstance() {
+        return (ConfigurableItem) new ConfigurableItem(this) {
             @Override
             public String getUnlocalizedName(ItemStack itemStack) {
                 return super.getUnlocalizedName(itemStack) + (itemStack.getMetadata() == 0 ? ".output" : ".input");


### PR DESCRIPTION
Like the corresponding CyclopsCore change, this should be fully backwards-compatible (both source and binary) due to Java's support for covariant return types.