### PR TITLE
Allow opening GUIs without power

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/client/gui/GuiPartWriter.java
+++ b/src/main/java/org/cyclops/integrateddynamics/client/gui/GuiPartWriter.java
@@ -49,7 +49,8 @@ public class GuiPartWriter<P extends IPartTypeWriter<P, S> & IGuiContainerProvid
     @Override
     protected void drawAdditionalElementInfoForeground(ContainerMultipartAspects<P, S, IAspectWrite> container, int index, IAspectWrite aspect, int mouseX, int mouseY) {
         // Render error tooltip
-        displayErrors.drawForeground(getPartState().getErrors(aspect), ERROR_X, ERROR_Y + container.getAspectBoxHeight() * index, mouseX, mouseY, this, this.guiLeft, this.guiTop);
+        if(getPartState().isEnabled())
+            displayErrors.drawForeground(getPartState().getErrors(aspect), ERROR_X, ERROR_Y + container.getAspectBoxHeight() * index, mouseX, mouseY, this, this.guiLeft, this.guiTop);
     }
 
     @Override
@@ -64,8 +65,9 @@ public class GuiPartWriter<P extends IPartTypeWriter<P, S> & IGuiContainerProvid
         itemRender.renderItemAndEffectIntoGUI(itemStack, pos.x, pos.y);
 
         // Render error symbol
-        displayErrors.drawBackground(getPartState().getErrors(aspect), ERROR_X, ERROR_Y + aspectBoxHeight * index, OK_X, OK_Y + aspectBoxHeight * index, this,
-                this.guiLeft, this.guiTop, getPartState().getActiveAspect() == aspect);
+        if(getPartState().isEnabled())
+            displayErrors.drawBackground(getPartState().getErrors(aspect), ERROR_X, ERROR_Y + aspectBoxHeight * index, OK_X, OK_Y + aspectBoxHeight * index, this,
+                    this.guiLeft, this.guiTop, getPartState().getActiveAspect() == aspect);
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/PartTypeBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/PartTypeBase.java
@@ -186,7 +186,7 @@ public abstract class PartTypeBase<P extends IPartType<P, S>, S extends IPartSta
     public boolean onPartActivated(World world, BlockPos pos, S partState, EntityPlayer player, EnumHand hand,
                                    ItemStack heldItem, EnumFacing side, float hitX, float hitY, float hitZ) {
         // Drop through if the player is sneaking
-        if(player.isSneaking() || !partState.isEnabled()) {
+        if(player.isSneaking()) {
             return false;
         }
 

--- a/src/main/java/org/cyclops/integrateddynamics/inventory/container/ContainerPartReader.java
+++ b/src/main/java/org/cyclops/integrateddynamics/inventory/container/ContainerPartReader.java
@@ -161,16 +161,20 @@ public class ContainerPartReader<P extends IPartTypeReader<P, S> & IGuiContainer
                 for (IAspectRead aspectRead : getUnfilteredItems()) {
                     String readValue = "";
                     int readValueColor = 0;
-                    IVariable variable = getPartType().getVariable(getTarget(), getPartState(), aspectRead);
-                    if (variable != null) {
-                        try {
-                            IValue value = variable.getValue();
-                            readValue = value.getType().toCompactString(value);
-                            readValueColor = variable.getType().getDisplayColor();
-                        } catch (EvaluationException | NullPointerException e) {
-                            readValue = "ERROR";
-                            readValueColor = Helpers.RGBToInt(255, 0, 0);
+                    if(getPartState().isEnabled()) {
+                        IVariable variable = getPartType().getVariable(getTarget(), getPartState(), aspectRead);
+                        if (variable != null) {
+                            try {
+                                IValue value = variable.getValue();
+                                readValue = value.getType().toCompactString(value);
+                                readValueColor = variable.getType().getDisplayColor();
+                            } catch (EvaluationException | NullPointerException e) {
+                                readValue = "ERROR";
+                                readValueColor = Helpers.RGBToInt(255, 0, 0);
+                            }
                         }
+                    } else {
+                        readValue = "NO POWER";
                     }
 
                     setReadValue(aspectRead, Pair.of(readValue, readValueColor));

--- a/src/main/java/org/cyclops/integrateddynamics/inventory/container/ContainerPartWriter.java
+++ b/src/main/java/org/cyclops/integrateddynamics/inventory/container/ContainerPartWriter.java
@@ -95,7 +95,9 @@ public class ContainerPartWriter<P extends IPartTypeWriter<P, S> & IGuiContainer
             if(!MinecraftHelpers.isClientSide()) {
                 String writeValue = "";
                 int writeValueColor = 0;
-                if(getPartState().hasVariable()) {
+                if(!getPartState().isEnabled()) {
+                    writeValue = "NO POWER";
+                } else if(getPartState().hasVariable()) {
                     IPartNetwork partNetwork = NetworkHelpers.getPartNetwork(
                             NetworkHelpers.getNetwork(getPartContainer().getPosition().getWorld(),
                                     getPartContainer().getPosition().getBlockPos()));


### PR DESCRIPTION
Once channels become a thing, this will be the only way to fix an incorrect
channel. Readers and writers are marked with "NO POWER" instead of displaying
any useful information. Fixes half of #324.