### PR TITLE
Fix #331: don't crash over an aspect model not being found

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/client/model/AspectVariableModelProvider.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/model/AspectVariableModelProvider.java
@@ -25,13 +25,9 @@ public class AspectVariableModelProvider implements IVariableModelProvider<Baked
     public BakedMapVariableModelProvider<IAspect> bakeOverlayModels(IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter) {
         Map<IAspect, IBakedModel> bakedModels = Maps.newHashMap();
         for(IAspect aspect : Aspects.REGISTRY.getAspects()) {
-            try {
-                IModel model = ModelLoaderRegistry.getModel(Aspects.REGISTRY.getAspectModel(aspect));
-                IBakedModel bakedAspectModel = model.bake(state, format, bakedTextureGetter);
-                bakedModels.put(aspect, bakedAspectModel);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            IModel model = ModelLoaderRegistry.getModelOrLogError(Aspects.REGISTRY.getAspectModel(aspect), "Could not find a model for aspect " + aspect.getUnlocalizedName());
+            IBakedModel bakedAspectModel = model.bake(state, format, bakedTextureGetter);
+            bakedModels.put(aspect, bakedAspectModel);
         }
         return new BakedMapVariableModelProvider<>(bakedModels);
     }


### PR DESCRIPTION
This gives you a nice big error from Forge in the log, but lets you use the
aspect anyway. This will make it much easier to code new aspects and worry
about the models later.