### PR TITLE
Add a recipe to squeeze menril resin out of planks

### DIFF
--- a/src/main/resources/assets/integrateddynamics/recipes/squeezer.xml
+++ b/src/main/resources/assets/integrateddynamics/recipes/squeezer.xml
@@ -17,6 +17,19 @@
 	<recipe type="integrateddynamics:squeezer">
 		<tag>base</tag>
 		<condition type="config">squeezer</condition>
+		<condition type="config">menril_planks</condition>
+		<condition type="config">menrilresin</condition>
+		<input>
+			<item>integrateddynamics:menril_planks</item>
+		</input>
+		<output>
+			<fluid amount="250">menrilresin</fluid>
+		</output>
+	</recipe>
+
+	<recipe type="integrateddynamics:squeezer">
+		<tag>base</tag>
+		<condition type="config">squeezer</condition>
 		<condition type="config">liquidchorus</condition>
 		<input>
 			<item>minecraft:chorus_fruit_popped</item>


### PR DESCRIPTION
It's easy to habitually turn all of your logs into planks, not realizing that
menril logs' main functionality requires that you don't. Give players who
accidentally do a way to get the resin anyway, at the expense of taking 4
times as long.