### PR TITLE
Make cable connections side aware

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementCable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementCable.java
@@ -26,7 +26,7 @@ public abstract class PathElementCable extends PathElementDefault {
         for (EnumFacing side : EnumFacing.VALUES) {
             if (getCable().isConnected(side)) {
                 BlockPos posOffset = pos.offset(side);
-                IPathElement pathElement = TileHelpers.getCapability(getPosition().getWorld(), posOffset, PathElementConfig.CAPABILITY);
+                IPathElement pathElement = TileHelpers.getCapability(getPosition().getWorld(), posOffset, side.getOpposite(), PathElementConfig.CAPABILITY);
                 if (pathElement == null) {
                     IntegratedDynamics.clog(Level.ERROR, String.format("The position at %s was incorrectly marked " +
                             "as reachable as path element by %s at %s side %s.", posOffset, getCable(), pos, side));

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
@@ -60,6 +60,18 @@ public class CableHelpers {
     }
 
     /**
+     * Get the cable capability at the given position with the given side.
+     *
+     * @param world The world.
+     * @param pos The position.
+     * @param side The side to check
+     * @return The cable capability, or null if not present.
+     */
+    public static @Nullable ICable getCable(IBlockAccess world, BlockPos pos, EnumFacing side) {
+        return TileHelpers.getCapability(world, pos, side, CableConfig.CAPABILITY);
+    }
+
+    /**
      * Get the fakeable cable capability at the given position.
      * @param world The world.
      * @param pos The position.
@@ -129,7 +141,7 @@ public class CableHelpers {
      */
     public static boolean canCableConnectTo(IBlockAccess world, BlockPos pos, EnumFacing side, ICable originCable) {
         BlockPos neighbourPos = pos.offset(side);
-        ICable neighbourCable = getCable(world, neighbourPos);
+        ICable neighbourCable = getCable(world, neighbourPos, side.getOpposite());
         return neighbourCable != null
                 && originCable.canConnect(neighbourCable, side)
                 && neighbourCable.canConnect(originCable, side.getOpposite());


### PR DESCRIPTION
The mod Compact Machines adds a block that allows each of its faces
to be "connected" to a different block in a different dimension.
Because each face could be a different network/grid/system entirely
it requires the capabilities to be sided to be "proxied".

With this commit the path checks ask for the proper side of the
neighboring block instead of passing null to the capability checker
/getter.

This should not have any bad effects on the given cable system and
allows Integrated Dynamics to work with Compact Machines and other
Forge Capability proxying blocks (like Phantom Faces?) that require
a sided capability.