### PR TITLE
Give 3 omni-directional connectors instead of 2 when consuming one

### DIFF
--- a/src/main/resources/assets/integrateddynamics/recipes/shaped.xml
+++ b/src/main/resources/assets/integrateddynamics/recipes/shaped.xml
@@ -1167,7 +1167,7 @@
 			</grid>
 		</input>
 		<output>
-			<item amount="2">integrateddynamics:part_connector_omni_directional_item</item>
+			<item amount="3">integrateddynamics:part_connector_omni_directional_item</item>
 		</output>
 	</recipe>
 


### PR DESCRIPTION
It isn't really fair to make the recipe effectively twice as expensive just
to join one to an existing pair.