### PR TITLE
Fix IgnoredBlockStatus only handling valid enums

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/block/IgnoredBlockStatus.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/block/IgnoredBlockStatus.java
@@ -48,7 +48,11 @@ public class IgnoredBlockStatus extends IgnoredBlock {
 
         @Override
         public Optional<Status> parseValue(String value) {
-            return Optional.fromNullable(Status.valueOf(value.toUpperCase(Locale.ENGLISH)));
+            try {
+                return Optional.of(Status.valueOf(value.toUpperCase(Locale.ENGLISH)));
+            } catch (IllegalArgumentException e) {
+                return Optional.absent();
+            }
         }
 
         @Override


### PR DESCRIPTION
This catches the potential IllegalArgumentException that might get thrown if some-one passes something that isn't a valid enum value in Status, such as "hello" into the function. This now matches the behaviour of vanilla minecraft's PropertyEnum.parseValue, which stores it in an internal map (of whose get function never throws).

I'm not sure when this could happen in vanilla, however it looks like some commands and advancement criteria call this in order to parse their respective strings.

This was found with an in-dev version of buildcraft (https://gist.github.com/LuigiHutch/89da294073722bab676e2a77a69c63ea)