### PR TITLE
Make aspects (and operators) only update on block updates

### DIFF
--- a/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/DummyVariable.java
+++ b/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/DummyVariable.java
@@ -35,6 +35,21 @@ public class DummyVariable<V extends IValue> implements IVariable<V> {
         return value;
     }
 
+    @Override
+    public boolean canInvalidate() {
+        return true;
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    @Override
+    public void addDependent(IVariable<?> dependent) {
+
+    }
+
     public void setValue(V value) {
         this.value = value;
     }

--- a/src/main/java/org/cyclops/integrateddynamics/api/evaluate/expression/ILazyExpressionValueCache.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/evaluate/expression/ILazyExpressionValueCache.java
@@ -12,5 +12,6 @@ public interface ILazyExpressionValueCache {
     public void setValue(int id, IValue value);
     public boolean hasValue(int id);
     public IValue getValue(int id);
+    public void removeValue(int id);
 
 }

--- a/src/main/java/org/cyclops/integrateddynamics/api/evaluate/expression/VariableAdapter.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/evaluate/expression/VariableAdapter.java
@@ -1,0 +1,36 @@
+package org.cyclops.integrateddynamics.api.evaluate.expression;
+
+import com.google.common.collect.Lists;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
+
+import java.util.List;
+
+/**
+ * A basic variable implementation.
+ * @author rubensworks
+ */
+public abstract class VariableAdapter<V extends IValue> implements IVariable<V> {
+
+    private List<IVariable<?>> dependents = Lists.newLinkedList();
+
+    @Override
+    public boolean canInvalidate() {
+        return true;
+    }
+
+    @Override
+    public void invalidate() {
+        for (IVariable<?> dependent : dependents) {
+            if (dependent.canInvalidate()) {
+                dependent.invalidate();
+            }
+        }
+        dependents.clear();
+    }
+
+    @Override
+    public void addDependent(IVariable<?> dependent) {
+        dependents.add(dependent);
+    }
+}

--- a/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IVariable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IVariable.java
@@ -19,4 +19,24 @@ public interface IVariable<V extends IValue> {
      */
     public V getValue() throws EvaluationException;
 
+    /**
+     * @return If this aspect has a state that can be invalidated.
+     */
+    public boolean canInvalidate();
+
+    /**
+     * Called when this variable should be invalidated.
+     * This is only called when required, so there is no guarantee that this is called in a regular pattern.
+     */
+    public void invalidate();
+
+    /**
+     * Add a dependency relation.
+     * This makes it so that when a certain variable gets invalidated,
+     * all dependent variables also become invalidated.
+     * This invalidation should happen recursively.
+     * @param dependent A variable that depends on this.
+     */
+    public void addDependent(IVariable<?> dependent);
+
 }

--- a/src/main/java/org/cyclops/integrateddynamics/api/network/INetworkElement.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/network/INetworkElement.java
@@ -91,7 +91,8 @@ public interface INetworkElement extends Comparable<INetworkElement> {
 
     /**
      * Called when a neighbouring block is updated, more specifically when
-     * {@link net.minecraft.block.Block#neighborChanged(IBlockState, World, BlockPos, Block, BlockPos)} is called.
+     * {@link net.minecraft.block.Block#neighborChanged(IBlockState, World, BlockPos, Block, BlockPos)} or
+     * {@link Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} is called.
      * @param network The network to update in.
      * @param world The world in which the neighbour was updated.
      * @param neighborBlock block type of the neighbour that was updated.

--- a/src/main/java/org/cyclops/integrateddynamics/api/part/IPartType.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/part/IPartType.java
@@ -324,7 +324,8 @@ public interface IPartType<P extends IPartType<P, S>, S extends IPartState<P>> e
 
     /**
      * Called when a neighbouring block is updated, more specifically when
-     * {@link net.minecraft.block.Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} is called.
+     * {@link net.minecraft.block.Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} or
+     * {@link Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} is called.
      * @param network The network to update in.
      * @param partNetwork The part network to update in.
      * @param target The target block.

--- a/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/AspectUpdateType.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/AspectUpdateType.java
@@ -1,0 +1,31 @@
+package org.cyclops.integrateddynamics.api.part.aspect;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import org.cyclops.integrateddynamics.api.network.IPartNetwork;
+import org.cyclops.integrateddynamics.api.part.IPartState;
+import org.cyclops.integrateddynamics.api.part.IPartType;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+
+/**
+ * Different types of aspect update triggers.
+ * I.e., when {@link IAspect#update(IPartNetwork, IPartType, PartTarget, IPartState)} should be called.
+ * @author rubensworks
+ */
+public enum AspectUpdateType {
+    /**
+     * Update per network tick.
+     */
+    NETWORK_TICK,
+    /**
+     * Update its value on block neigbour changes,
+     * i.e., if {@link net.minecraft.block.Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} or
+     * {@link Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} is called.
+     */
+    BLOCK_UPDATE,
+    /**
+     * If the update method should never be called.
+     */
+    NEVER
+}

--- a/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/IAspectRead.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/IAspectRead.java
@@ -17,4 +17,9 @@ public interface IAspectRead<V extends IValue, T extends IValueType<V>> extends 
      */
     public IAspectVariable<V> createNewVariable(PartTarget target);
 
+    /**
+     * @return The update type on which this aspect should invalidate.
+     */
+    public AspectUpdateType getUpdateType();
+
 }

--- a/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/IAspectVariable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/part/aspect/IAspectVariable.java
@@ -16,17 +16,6 @@ public interface IAspectVariable<V extends IValue> extends IVariable<V> {
     public PartTarget getTarget();
 
     /**
-     * @return If this aspect requires updating.
-     */
-    public boolean requiresUpdate();
-
-    /**
-     * Called when this variable should update.
-     * This is only called when required, so there is no guarantee that this is called in a regular pattern.
-     */
-    public void update();
-
-    /**
      * @return The referenced aspect.
      */
     public IAspectRead<V, ?> getAspect();

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
@@ -298,6 +298,14 @@ public class BlockCable extends ConfigurableBlockContainer implements ICollidabl
     }
 
     @Override
+    public void onNeighborChange(IBlockAccess world, BlockPos pos, BlockPos neighbor) {
+        super.onNeighborChange(world, pos, neighbor);
+        if (world instanceof World) {
+            NetworkHelpers.onElementProviderBlockNeighborChange((World) world, pos, world.getBlockState(neighbor).getBlock());
+        }
+    }
+
+    @Override
     public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
         super.updateTick(world, pos, state, rand);
         TileMultipartTicking tile = TileHelpers.getSafeTile(world, pos, TileMultipartTicking.class);

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/CompositionalOperator.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/CompositionalOperator.java
@@ -2,6 +2,7 @@ package org.cyclops.integrateddynamics.core.evaluate.operator;
 
 import org.cyclops.cyclopscore.helper.L10NHelpers;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.expression.VariableAdapter;
 import org.cyclops.integrateddynamics.api.evaluate.operator.IOperator;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
@@ -103,7 +104,7 @@ public class CompositionalOperator extends OperatorBase {
                 for(int i = 0; i < builders.length; i++) {
                     final AppliedOperatorBuilder builder = builders[i];
                     // Anonymous class because we want lazy evaluation
-                    subVariablesOut[i] = new IVariable() {
+                    subVariablesOut[i] = new VariableAdapter<IValue>() {
                         @Override
                         public IValueType getType() {
                             return builder.base.getOutputType();

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/Variable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/Variable.java
@@ -1,15 +1,15 @@
 package org.cyclops.integrateddynamics.core.evaluate.variable;
 
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.expression.VariableAdapter;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
-import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
 
 /**
  * A default variable implementation.
  * @author rubensworks
  */
-public class Variable<V extends IValue> implements IVariable<V> {
+public class Variable<V extends IValue> extends VariableAdapter<V> {
 
     private final IValueType<V> type;
     private final V value;

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
@@ -108,7 +108,8 @@ public class NetworkHelpers {
     /**
      * This MUST be called by blocks having the {@link INetworkElementProvider} capability in
      * when a neighbouring block is updated, more specifically when
-     * {@link net.minecraft.block.Block#neighborChanged(IBlockState, World, BlockPos, Block, BlockPos)} is called.
+     * {@link net.minecraft.block.Block#neighborChanged(IBlockState, World, BlockPos, Block, BlockPos)}
+     * or {@link Block#onNeighborChange(IBlockAccess, BlockPos, BlockPos)} is called.
      * @param world The world in which the neighbour was updated.
      * @param pos The position of the center block.
      * @param neighborBlock The block type of the neighbour that was updated.

--- a/src/main/java/org/cyclops/integrateddynamics/core/item/VariableFacadeHandlerRegistry.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/item/VariableFacadeHandlerRegistry.java
@@ -13,6 +13,7 @@ import org.cyclops.cyclopscore.helper.L10NHelpers;
 import org.cyclops.cyclopscore.helper.MinecraftHelpers;
 import org.cyclops.integrateddynamics.api.client.model.IVariableModelBaked;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.expression.VariableAdapter;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
@@ -156,7 +157,7 @@ public class VariableFacadeHandlerRegistry implements IVariableFacadeHandlerRegi
      */
     public static class DummyVariableFacade extends VariableFacadeBase {
 
-        private static final IVariable VARIABLE_TRUE = new IVariable<ValueTypeBoolean.ValueBoolean>() {
+        private static final IVariable VARIABLE_TRUE = new VariableAdapter<ValueTypeBoolean.ValueBoolean>() {
             @Override
             public IValueType<ValueTypeBoolean.ValueBoolean> getType() {
                 return ValueTypes.BOOLEAN;

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/PartNetwork.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/PartNetwork.java
@@ -157,6 +157,11 @@ public class PartNetwork extends FullNetworkListenerAdapter implements IPartNetw
     }
 
     @Override
+    public void removeValue(int id) {
+        lazyExpressionValueCache.remove(id);
+    }
+
+    @Override
     public boolean addVariableContainer(DimPos dimPos) {
         compositeVariableCache = null;
         return variableContainerPositions.add(dimPos);
@@ -198,9 +203,6 @@ public class PartNetwork extends FullNetworkListenerAdapter implements IPartNetw
 
     @Override
     public void update() {
-        // Reset lazy variable cache
-        lazyExpressionValueCache.clear();
-
         // Signal parts of any changes
         if (partsChanged) {
             this.partsChanged = false;

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/LazyAspectVariable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/LazyAspectVariable.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.expression.VariableAdapter;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
 import org.cyclops.integrateddynamics.api.part.IPartState;
@@ -19,7 +20,7 @@ import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties
  * No calculations will be done if the value of this variable is not called.
  * @author rubensworks
  */
-public abstract class LazyAspectVariable<V extends IValue> implements IAspectVariable<V> {
+public abstract class LazyAspectVariable<V extends IValue> extends VariableAdapter<V> implements IAspectVariable<V> {
 
     @Getter private final IValueType<V> type;
     @Getter private final PartTarget target;
@@ -34,12 +35,13 @@ public abstract class LazyAspectVariable<V extends IValue> implements IAspectVar
     }
 
     @Override
-    public boolean requiresUpdate() {
+    public boolean canInvalidate() {
         return value != null;
     }
 
     @Override
-    public void update() {
+    public void invalidate() {
+        super.invalidate();
         value = null;
         cachedProperties = null;
     }

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/UpdatingAspectVariable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/UpdatingAspectVariable.java
@@ -24,9 +24,4 @@ public abstract class UpdatingAspectVariable<V extends IValue> implements IAspec
         this.value = type.getDefault();
     }
 
-    @Override
-    public boolean requiresUpdate() {
-        return true;
-    }
-
 }

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/build/AspectBuilder.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/aspect/build/AspectBuilder.java
@@ -14,6 +14,7 @@ import org.cyclops.integrateddynamics.api.network.IPartNetwork;
 import org.cyclops.integrateddynamics.api.part.IPartState;
 import org.cyclops.integrateddynamics.api.part.IPartType;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.AspectUpdateType;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectRead;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectWrite;
 import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
@@ -47,11 +48,13 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
     private final ModBase modGui;
     private final List<IAspectUpdateListener.Before> beforeUpdateListeners;
     private final List<IAspectUpdateListener.After> afterUpdateListeners;
+    private final AspectUpdateType updateType;
 
     private AspectBuilder(boolean read, T valueType, List<String> kinds, IAspectProperties defaultAspectProperties,
                           List<IAspectValuePropagator> valuePropagators, List<IAspectWriteActivator> writeActivators,
                           List<IAspectWriteDeactivator> writeDeactivators, ModBase mod, ModBase modGui,
-                          List<IAspectUpdateListener.Before> beforeUpdateListeners, List<IAspectUpdateListener.After> afterUpdateListeners) {
+                          List<IAspectUpdateListener.Before> beforeUpdateListeners, List<IAspectUpdateListener.After> afterUpdateListeners,
+                          AspectUpdateType updateType) {
         this.read = read;
         this.valueType = valueType;
         this.kinds = kinds;
@@ -63,6 +66,7 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
         this.modGui = Objects.requireNonNull(modGui);
         this.beforeUpdateListeners = beforeUpdateListeners;
         this.afterUpdateListeners = afterUpdateListeners;
+        this.updateType = updateType;
     }
 
     /**
@@ -93,7 +97,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -112,7 +117,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -131,7 +137,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -154,7 +161,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -177,7 +185,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -196,7 +205,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -215,7 +225,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 beforeUpdateListeners,
-                afterUpdateListeners);
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -234,7 +245,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 Helpers.joinList(beforeUpdateListeners, listener),
-                Helpers.joinList(afterUpdateListeners, null));
+                Helpers.joinList(afterUpdateListeners, null),
+                updateType);
     }
 
     /**
@@ -253,7 +265,30 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
                 mod,
                 modGui,
                 Helpers.joinList(beforeUpdateListeners, null),
-                Helpers.joinList(afterUpdateListeners, listener));
+                Helpers.joinList(afterUpdateListeners, listener),
+                updateType);
+    }
+
+    /**
+     * Set the update type of the reader aspect.
+     * @return The new builder instance.
+     */
+    public AspectBuilder<V, T, O> withUpdateType(AspectUpdateType updateType) {
+        if(!this.read) {
+            throw new RuntimeException("Custom update types are only applicable to readers.");
+        }
+        return new AspectBuilder<>(
+                this.read, this.valueType,
+                Helpers.joinList(this.kinds, null),
+                this.defaultAspectProperties,
+                Helpers.joinList(this.valuePropagators, null),
+                Helpers.joinList(writeActivators, null),
+                Helpers.joinList(writeDeactivators, null),
+                mod,
+                modGui,
+                beforeUpdateListeners,
+                afterUpdateListeners,
+                updateType);
     }
 
     /**
@@ -286,7 +321,7 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
     public static <V extends IValue, T extends IValueType<V>> AspectBuilder<V, T, Pair<PartTarget, IAspectProperties>> forReadType(T valueType) {
         return new AspectBuilder<>(true, valueType, ImmutableList.of(valueType.getTypeName()), null,
                 Collections.<IAspectValuePropagator>emptyList(), Collections.<IAspectWriteActivator>emptyList(),
-                Collections.<IAspectWriteDeactivator>emptyList(), IntegratedDynamics._instance, IntegratedDynamics._instance, Lists.newArrayList(), Lists.newArrayList());
+                Collections.<IAspectWriteDeactivator>emptyList(), IntegratedDynamics._instance, IntegratedDynamics._instance, Lists.newArrayList(), Lists.newArrayList(), AspectUpdateType.NETWORK_TICK);
     }
 
     /**
@@ -299,7 +334,7 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
     public static <V extends IValue, T extends IValueType<V>> AspectBuilder<V, T, Triple<PartTarget, IAspectProperties, IVariable<V>>> forWriteType(T valueType) {
         return new AspectBuilder<>(false, valueType, ImmutableList.of(valueType.getTypeName()), null,
                 Collections.<IAspectValuePropagator>emptyList(), Collections.<IAspectWriteActivator>emptyList(),
-                Collections.<IAspectWriteDeactivator>emptyList(), IntegratedDynamics._instance, IntegratedDynamics._instance, Lists.newArrayList(), Lists.newArrayList());
+                Collections.<IAspectWriteDeactivator>emptyList(), IntegratedDynamics._instance, IntegratedDynamics._instance, Lists.newArrayList(), Lists.newArrayList(), AspectUpdateType.NETWORK_TICK);
     }
 
     private static class BuiltReader<V extends IValue, T extends IValueType<V>> extends AspectReadBase<V, T> {
@@ -311,7 +346,8 @@ public class AspectBuilder<V extends IValue, T extends IValueType<V>, O> {
 
         public BuiltReader(AspectBuilder<V, T, V> aspectBuilder) {
             super(aspectBuilder.mod, aspectBuilder.modGui,
-                    deriveUnlocalizedType(aspectBuilder), aspectBuilder.defaultAspectProperties);
+                    deriveUnlocalizedType(aspectBuilder), aspectBuilder.defaultAspectProperties,
+                    aspectBuilder.updateType);
             this.valueType = aspectBuilder.valueType;
             this.valuePropagators = aspectBuilder.valuePropagators;
             this.beforeUpdateListeners = aspectBuilder.beforeUpdateListeners;

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/panel/PartTypePanelVariableDriven.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/panel/PartTypePanelVariableDriven.java
@@ -138,9 +138,9 @@ public abstract class PartTypePanelVariableDriven<P extends PartTypePanelVariabl
             // Since sendUpdate marks a flag for the part to update, this caused a loss of one tick.
             // For example:
             // tick-0: Tile tick
-            // tick-0: Part tick: update a value, and mark part to update
+            // tick-0: Part tick: update a value, and mark part to invalidate
             // tick-0: -- send all block updates to client ---
-            // tick-1: Tile tick: notices and update, marks a block update
+            // tick-1: Tile tick: notices and update, marks a block invalidate
             // tick-1: Part tick: update the value again, the old value has still not been sent here!
             // tick-1: -- send all block updates to client --- This will contain the value that was set in tick-1.
             state.onDirty();

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/read/PartTypeReadBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/read/PartTypeReadBase.java
@@ -1,8 +1,11 @@
 package org.cyclops.integrateddynamics.core.part.read;
 
+import com.google.common.collect.Sets;
+import net.minecraft.block.Block;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.inventory.Container;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
@@ -11,6 +14,7 @@ import org.cyclops.integrateddynamics.api.network.INetwork;
 import org.cyclops.integrateddynamics.api.network.IPartNetwork;
 import org.cyclops.integrateddynamics.api.part.PartRenderPosition;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.AspectUpdateType;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectRead;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectVariable;
@@ -22,7 +26,9 @@ import org.cyclops.integrateddynamics.inventory.container.ContainerPartReader;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
 
 import javax.annotation.Nullable;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Set;
 
 /**
  * An abstract {@link IPartTypeReader}.
@@ -32,13 +38,31 @@ public abstract class PartTypeReadBase<P extends IPartTypeReader<P, S>, S extend
         extends PartTypeAspects<P, S> implements IPartTypeReader<P, S> {
 
     private List<IAspectRead> aspectsRead = null;
+    private EnumMap<AspectUpdateType, Set<IAspectRead>> updateAspects = null;
 
     public PartTypeReadBase(String name) {
-        super(name, new PartRenderPosition(0.1875F, 0.3125F, 0.625F, 0.625F));
+        this(name, new PartRenderPosition(0.1875F, 0.3125F, 0.625F, 0.625F));
     }
 
     public PartTypeReadBase(String name, PartRenderPosition partRenderPosition) {
         super(name, partRenderPosition);
+    }
+
+    protected Set<IAspectRead> getUpdateAspects(AspectUpdateType updateType) {
+        if (updateAspects == null) {
+            updateAspects = new EnumMap<>(AspectUpdateType.class);
+            for (AspectUpdateType aspectUpdateType : AspectUpdateType.values()) {
+                updateAspects.put(aspectUpdateType, Sets.newLinkedHashSet());
+            }
+            for (IAspect aspect : getAspects()) {
+                if (aspect instanceof IAspectRead) {
+                    IAspectRead aspectRead = (IAspectRead) aspect;
+                    updateAspects.get(aspectRead.getUpdateType()).add(aspectRead);
+                }
+            }
+        }
+
+        return updateAspects.get(updateType);
     }
 
     @Override
@@ -54,7 +78,15 @@ public abstract class PartTypeReadBase<P extends IPartTypeReader<P, S>, S extend
     @Override
     public void update(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.update(network, partNetwork, target, state);
-        for(IAspect aspect : getAspects()) {
+        for(IAspect aspect : getUpdateAspects(AspectUpdateType.NETWORK_TICK)) {
+            aspect.update(partNetwork, this, target, state);
+        }
+    }
+
+    @Override
+    public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, IBlockAccess world, Block neighborBlock) {
+        super.onBlockNeighborChange(network, partNetwork, target, state, world, neighborBlock);
+        for(IAspect aspect : getUpdateAspects(AspectUpdateType.BLOCK_UPDATE)) {
             aspect.update(partNetwork, this, target, state);
         }
     }

--- a/src/main/java/org/cyclops/integrateddynamics/part/aspect/Aspects.java
+++ b/src/main/java/org/cyclops/integrateddynamics/part/aspect/Aspects.java
@@ -39,6 +39,7 @@ import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.network.IEnergyConsumingNetworkElement;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.AspectUpdateType;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectRead;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectRegistry;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectWrite;
@@ -94,28 +95,34 @@ public class Aspects {
             public static final IAspectRead<ValueTypeBoolean.ValueBoolean, ValueTypeBoolean> BOOLEAN_BLOCK =
                     AspectReadBuilders.Block.BUILDER_BOOLEAN.handle(
                         dimPos -> dimPos.getWorld().getBlockState(dimPos.getBlockPos()).getBlock() != Blocks.AIR
-                    ).handle(AspectReadBuilders.PROP_GET_BOOLEAN, "block").buildRead();
+                    ).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_BOOLEAN, "block").buildRead();
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_DIMENSION =
                     AspectReadBuilders.Block.BUILDER_INTEGER.handle(AspectReadBuilders.World.PROP_GET_WORLD).handle(
                         world -> world.provider.getDimension()
-                    ).handle(AspectReadBuilders.PROP_GET_INTEGER, "dimension").buildRead();
+                    ).withUpdateType(AspectUpdateType.NEVER)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "dimension").buildRead();
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_POSX =
                     AspectReadBuilders.Block.BUILDER_INTEGER.handle(AspectReadBuilders.World.PROP_GET_POS).handle(
                         BlockPos::getX
-                    ).handle(AspectReadBuilders.PROP_GET_INTEGER, "posx").buildRead();
+                    ).withUpdateType(AspectUpdateType.NEVER)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "posx").buildRead();
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_POSY =
                     AspectReadBuilders.Block.BUILDER_INTEGER.handle(AspectReadBuilders.World.PROP_GET_POS).handle(
                         BlockPos::getY
-                    ).handle(AspectReadBuilders.PROP_GET_INTEGER, "posy").buildRead();
+                    ).withUpdateType(AspectUpdateType.NEVER)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "posy").buildRead();
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_POSZ =
                     AspectReadBuilders.Block.BUILDER_INTEGER.handle(AspectReadBuilders.World.PROP_GET_POS).handle(
                         BlockPos::getZ
-                    ).handle(AspectReadBuilders.PROP_GET_INTEGER, "posz").buildRead();
+                    ).withUpdateType(AspectUpdateType.NEVER)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "posz").buildRead();
             public static final IAspectRead<ValueObjectTypeBlock.ValueBlock, ValueObjectTypeBlock> BLOCK =
                     AspectReadBuilders.Block.BUILDER_BLOCK
                             .handle(
                         dimPos -> dimPos.getWorld().getBlockState(dimPos.getBlockPos())
-                    ).handle(AspectReadBuilders.PROP_GET_BLOCK).buildRead();
+                    ).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_BLOCK).buildRead();
             public static final IAspectRead<ValueTypeNbt.ValueNbt, ValueTypeNbt> NBT =
                     AspectReadBuilders.Block.BUILDER_NBT.handle(dimPos -> {
                         TileEntity tile = dimPos.getWorld().getTileEntity(dimPos.getBlockPos());
@@ -127,7 +134,8 @@ public class Aspects {
                             // Catch possible errors
                         }
                         return null;
-                    }).handle(AspectReadBuilders.PROP_GET_NBT, "tile").buildRead();
+                    }).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_NBT, "tile").buildRead();
         }
 
         public static final class Entity {
@@ -391,7 +399,8 @@ public class Aspects {
                     }).handle(AspectReadBuilders.PROP_GET_DOUBLE, "fillratio").buildRead();
 
             public static final IAspectRead<ValueTypeList.ValueList, ValueTypeList> LIST_ITEMSTACKS =
-                    AspectReadBuilders.BUILDER_LIST.appendKind("inventory").handle(AspectReadBuilders.Inventory.PROP_GET_LIST, "itemstacks").buildRead();
+                    AspectReadBuilders.BUILDER_LIST.appendKind("inventory")
+                            .handle(AspectReadBuilders.Inventory.PROP_GET_LIST, "itemstacks").buildRead();
 
             public static final IAspectRead<ValueObjectTypeItemStack.ValueItemStack, ValueObjectTypeItemStack> OBJECT_ITEM_STACK_SLOT =
                     AspectReadBuilders.Inventory.BUILDER_ITEMSTACK.handle(AspectReadBuilders.PROP_GET_ITEMSTACK).buildRead();
@@ -556,22 +565,27 @@ public class Aspects {
             public static final IAspectRead<ValueTypeBoolean.ValueBoolean, ValueTypeBoolean> BOOLEAN_LOW =
                     AspectReadBuilders.Redstone.BUILDER_BOOLEAN.handle(
                         input -> input == 0
-                    ).handle(AspectReadBuilders.PROP_GET_BOOLEAN, "low").buildRead();
+                    ).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_BOOLEAN, "low").buildRead();
             public static final IAspectRead<ValueTypeBoolean.ValueBoolean, ValueTypeBoolean> BOOLEAN_NONLOW =
                     AspectReadBuilders.Redstone.BUILDER_BOOLEAN.handle(
                         input -> input > 0
-                    ).handle(AspectReadBuilders.PROP_GET_BOOLEAN, "nonlow").buildRead();
+                    ).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_BOOLEAN, "nonlow").buildRead();
             public static final IAspectRead<ValueTypeBoolean.ValueBoolean, ValueTypeBoolean> BOOLEAN_HIGH =
                     AspectReadBuilders.Redstone.BUILDER_BOOLEAN.handle(
                         input -> input == 15
-                    ).handle(AspectReadBuilders.PROP_GET_BOOLEAN, "high").buildRead();
+                    ).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_BOOLEAN, "high").buildRead();
             public static final IAspectRead<ValueTypeBoolean.ValueBoolean, ValueTypeBoolean> BOOLEAN_CLOCK =
                     AspectReadBuilders.Redstone.BUILDER_BOOLEAN_CLOCK.handle(AspectReadBuilders.PROP_GET_BOOLEAN, "clock").buildRead();
 
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_VALUE =
-                    AspectReadBuilders.Redstone.BUILDER_INTEGER.handle(AspectReadBuilders.PROP_GET_INTEGER, "value").buildRead();
+                    AspectReadBuilders.Redstone.BUILDER_INTEGER.withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "value").buildRead();
             public static final IAspectRead<ValueTypeInteger.ValueInteger, ValueTypeInteger> INTEGER_COMPARATOR =
-                    AspectReadBuilders.Redstone.BUILDER_INTEGER_COMPARATOR.handle(AspectReadBuilders.PROP_GET_INTEGER, "comparator").buildRead();
+                    AspectReadBuilders.Redstone.BUILDER_INTEGER_COMPARATOR.withUpdateType(AspectUpdateType.BLOCK_UPDATE)
+                            .handle(AspectReadBuilders.PROP_GET_INTEGER, "comparator").buildRead();
 
         }
 

--- a/src/main/java/org/cyclops/integrateddynamics/part/aspect/Aspects.java
+++ b/src/main/java/org/cyclops/integrateddynamics/part/aspect/Aspects.java
@@ -134,8 +134,7 @@ public class Aspects {
                             // Catch possible errors
                         }
                         return null;
-                    }).withUpdateType(AspectUpdateType.BLOCK_UPDATE)
-                            .handle(AspectReadBuilders.PROP_GET_NBT, "tile").buildRead();
+                    }).handle(AspectReadBuilders.PROP_GET_NBT, "tile").buildRead();
         }
 
         public static final class Entity {

--- a/src/main/java/org/cyclops/integrateddynamics/part/aspect/read/AspectReadBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/part/aspect/read/AspectReadBase.java
@@ -12,6 +12,7 @@ import org.cyclops.integrateddynamics.api.network.IPartNetwork;
 import org.cyclops.integrateddynamics.api.part.IPartState;
 import org.cyclops.integrateddynamics.api.part.IPartType;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.AspectUpdateType;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectRead;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspectVariable;
 import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
@@ -29,13 +30,16 @@ public abstract class AspectReadBase<V extends IValue, T extends IValueType<V>> 
         implements IAspectRead<V, T> {
 
     private final String unlocalizedTypeSuffix;
+    private final AspectUpdateType updateType;
 
-    public AspectReadBase(ModBase mod, ModBase modGui, String unlocalizedTypeSuffix, IAspectProperties defaultProperties) {
+    public AspectReadBase(ModBase mod, ModBase modGui, String unlocalizedTypeSuffix,
+                          IAspectProperties defaultProperties, AspectUpdateType updateType) {
         super(mod, modGui, defaultProperties);
         if(unlocalizedTypeSuffix == null) {
             unlocalizedTypeSuffix = "";
         }
         this.unlocalizedTypeSuffix = unlocalizedTypeSuffix;
+        this.updateType = updateType;
         if(MinecraftHelpers.isClientSide()) {
             registerModelResourceLocation();
         }
@@ -45,8 +49,8 @@ public abstract class AspectReadBase<V extends IValue, T extends IValueType<V>> 
     @Override
     public <P extends IPartType<P, S>, S extends IPartState<P>> void update(IPartNetwork network, P partType, PartTarget target, S state) {
         IAspectVariable variable = ((IPartTypeReader) partType).getVariable(target, (IPartStateReader) state, this);
-        if (variable.requiresUpdate()) {
-            variable.update();
+        if (variable.canInvalidate()) {
+            variable.invalidate();
         }
     }
 
@@ -79,4 +83,8 @@ public abstract class AspectReadBase<V extends IValue, T extends IValueType<V>> 
         };
     }
 
+    @Override
+    public AspectUpdateType getUpdateType() {
+        return updateType;
+    }
 }

--- a/src/main/java/org/cyclops/integrateddynamics/tileentity/TileDelay.java
+++ b/src/main/java/org/cyclops/integrateddynamics/tileentity/TileDelay.java
@@ -16,6 +16,7 @@ import org.cyclops.cyclopscore.helper.MinecraftHelpers;
 import org.cyclops.cyclopscore.persist.nbt.NBTPersist;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
+import org.cyclops.integrateddynamics.api.evaluate.expression.VariableAdapter;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
 import org.cyclops.integrateddynamics.api.item.IDelayVariableFacade;
@@ -56,7 +57,7 @@ public class TileDelay extends TileProxy {
     private EntityPlayer lastPlayer = null;
 
     public TileDelay() {
-        this.variable = new IVariable<ValueTypeList.ValueList>() {
+        this.variable = new VariableAdapter<ValueTypeList.ValueList>() {
 
             @Override
             public ValueTypeList getType() {

--- a/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/DummyVariable.java
+++ b/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/DummyVariable.java
@@ -35,6 +35,21 @@ public class DummyVariable<V extends IValue> implements IVariable<V> {
         return value;
     }
 
+    @Override
+    public boolean canInvalidate() {
+        return true;
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    @Override
+    public void addDependent(IVariable<?> dependent) {
+
+    }
+
     public void setValue(V value) {
         this.value = value;
     }


### PR DESCRIPTION
This makes it so that certain aspect variables are not updated/invalidated every network tick anymore, but only when an actual block update is received.
These changes are then cascaded through to the operators.

Operations on fully static variables will now also not be invalidated every tick anymore.

@josephcsible This change may potentially break a lot of things, so I need a second set of eyes on this. Could you check if I didn't miss anything that could break with this change?