### PR TITLE
Fix another integration test

### DIFF
--- a/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/TestItemStackOperators.java
+++ b/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/TestItemStackOperators.java
@@ -23,6 +23,7 @@ import org.cyclops.integrateddynamics.block.BlockCreativeEnergyBattery;
 import org.cyclops.integrateddynamics.block.BlockEnergyBatteryConfig;
 import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
 import org.cyclops.integrateddynamics.core.evaluate.variable.*;
+import org.cyclops.integrateddynamics.core.helper.Helpers;
 import org.cyclops.integrateddynamics.core.test.IntegrationBefore;
 import org.cyclops.integrateddynamics.core.test.IntegrationTest;
 import org.cyclops.integrateddynamics.core.test.TestHelpers;
@@ -841,10 +842,10 @@ public class TestItemStackOperators {
     public void testItemStackOreDictStacks() throws EvaluationException {
         IValue res1 = Operators.OBJECT_ITEMSTACK_OREDICT_STACKS.evaluate(new IVariable[]{sStickWood});
         Asserts.check(res1 instanceof ValueTypeList.ValueList, "result is a list");
-        TestHelpers.assertEqual(((ValueTypeList.ValueList) res1).getRawValue().getLength(), OreDictionary.getOres("stickWood").size(), "size(oredict_stacks(stickWood))");
+        TestHelpers.assertEqual(((ValueTypeList.ValueList) res1).getRawValue().getLength(), (int)Helpers.getOresWildcard("stickWood").count(), "size(oredict_stacks(stickWood))");
 
         IValue res2 = Operators.OBJECT_ITEMSTACK_OREDICT_STACKS.evaluate(new IVariable[]{sPlankWood});
-        TestHelpers.assertEqual(((ValueTypeList.ValueList) res2).getRawValue().getLength(), OreDictionary.getOres("plankWood").size(), "size(oredict_stacks(plankWood))");
+        TestHelpers.assertEqual(((ValueTypeList.ValueList) res2).getRawValue().getLength(), (int)Helpers.getOresWildcard("plankWood").count(), "size(oredict_stacks(plankWood))");
     }
 
     @IntegrationTest(expected = EvaluationException.class)

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
@@ -1485,17 +1485,9 @@ public final class Operators {
                 ValueTypeString.ValueString a = variables.getValue(0);
                 ImmutableList.Builder<ValueObjectTypeItemStack.ValueItemStack> builder = ImmutableList.builder();
                 if (!StringUtils.isNullOrEmpty(a.getRawValue())) {
-                    for (ItemStack itemStack : OreDictionary.getOres(a.getRawValue())) {
-                        if (itemStack.getMetadata() == OreDictionary.WILDCARD_VALUE) {
-                            NonNullList<ItemStack> subItems = NonNullList.create();
-                            itemStack.getItem().getSubItems(CreativeTabs.SEARCH, subItems);
-                            for (ItemStack subItem : subItems) {
-                                builder.add(ValueObjectTypeItemStack.ValueItemStack.of(subItem));
-                            }
-                        } else {
-                            builder.add(ValueObjectTypeItemStack.ValueItemStack.of(itemStack));
-                        }
-                    }
+                    Helpers.getOresWildcard(a.getRawValue())
+                            .map(ValueObjectTypeItemStack.ValueItemStack::of)
+                            .forEach(builder::add);
                 }
                 return ValueTypeList.ValueList.ofList(ValueTypes.OBJECT_ITEMSTACK, builder.build());
             }).build());

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/Helpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/Helpers.java
@@ -3,10 +3,12 @@ package org.cyclops.integrateddynamics.core.helper;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -16,12 +18,14 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.oredict.OreDictionary;
 import org.cyclops.cyclopscore.datastructure.DimPos;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
 import org.cyclops.cyclopscore.helper.TileHelpers;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Helper methods.
@@ -63,6 +67,29 @@ public final class Helpers {
             }
         }
         return 0;
+    }
+
+    /**
+     * Retrieves a Stream of items that are registered to this ore type
+     * with wildcard meta values expanded out into sub items
+     *
+     * @param name The ore name, directly calls OreDictionary.getOres
+     * @return A Stream containing ItemStacks registered for this ore
+     */
+    public static Stream<ItemStack> getOresWildcard(String name) {
+        Stream.Builder<ItemStack> builder = Stream.builder();
+        for (ItemStack itemStack : OreDictionary.getOres(name)) {
+            if (itemStack.getMetadata() == OreDictionary.WILDCARD_VALUE) {
+                NonNullList<ItemStack> subItems = NonNullList.create();
+                itemStack.getItem().getSubItems(CreativeTabs.SEARCH, subItems);
+                for (ItemStack subItem : subItems) {
+                    builder.accept(subItem);
+                }
+            } else {
+                builder.accept(itemStack);
+            }
+        }
+        return builder.build();
     }
 
     /**


### PR DESCRIPTION
This pull request fixes one of the two remaining failing tests from https://github.com/CyclopsMC/IntegratedDynamics/pull/553

The problem was that the test was using the standard ore dictionary call but the operator was using a method where the wildcard item was expanded out into the individual items from the creative tab.

To fix the problem I moved the code that does the expansion into a helper function so that the test can use it too.