### PR TITLE
Fixed TestItemStackOperators#testItemStackStoredFe and creative energy battery appearing not to be full in creative tab

### DIFF
--- a/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/TestItemStackOperators.java
+++ b/src/integrationtest/org/cyclops/integrateddynamics/core/evaluate/variable/integration/TestItemStackOperators.java
@@ -20,6 +20,7 @@ import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
 import org.cyclops.integrateddynamics.block.BlockCreativeEnergyBattery;
+import org.cyclops.integrateddynamics.block.BlockEnergyBatteryBase;
 import org.cyclops.integrateddynamics.block.BlockEnergyBatteryConfig;
 import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
 import org.cyclops.integrateddynamics.core.evaluate.variable.*;
@@ -89,7 +90,7 @@ public class TestItemStackOperators {
         iEnergyBatteryEmpty = new DummyVariableItemStack(ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(BlockCreativeEnergyBattery.getInstance())));
         ItemStack energyBatteryFull = new ItemStack(BlockCreativeEnergyBattery.getInstance());
         IEnergyStorage energyStorage = energyBatteryFull.getCapability(CapabilityEnergy.ENERGY, null);
-        energyStorage.receiveEnergy(energyStorage.getMaxEnergyStored(), false);
+        BlockEnergyBatteryBase.fill(energyStorage);
         iEnergyBatteryFull = new DummyVariableItemStack(ValueObjectTypeItemStack.ValueItemStack.of(energyBatteryFull));
         iIronOre = new DummyVariableItemStack(ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(Blocks.IRON_ORE)));
         ItemStack shulkerBox = new ItemStack(Blocks.BLACK_SHULKER_BOX);
@@ -938,7 +939,7 @@ public class TestItemStackOperators {
         TestHelpers.assertEqual(((ValueTypeInteger.ValueInteger) res2).getRawValue(), 0, "storedfe(energyBatteryEmpty) == 0");
 
         IValue res3 = Operators.OBJECT_ITEMSTACK_STOREDFE.evaluate(new IVariable[]{iEnergyBatteryFull});
-        TestHelpers.assertEqual(((ValueTypeInteger.ValueInteger) res3).getRawValue(), 100000, "storedfe(energyBatteryFull) == 100000");
+        TestHelpers.assertEqual(((ValueTypeInteger.ValueInteger) res3).getRawValue(), BlockEnergyBatteryConfig.capacity, "storedfe(energyBatteryFull) == BlockEnergyBatteryConfig.capacity");
     }
 
     @IntegrationTest(expected = EvaluationException.class)

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCreativeEnergyBattery.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCreativeEnergyBattery.java
@@ -46,7 +46,7 @@ public class BlockCreativeEnergyBattery extends BlockEnergyBatteryBase {
         if (!BlockHelpers.isValidCreativeTab(this, tab)) return;
         ItemStack full = new ItemStack(this);
         IEnergyStorage energyStorage = full.getCapability(CapabilityEnergy.ENERGY, null);
-        energyStorage.receiveEnergy(energyStorage.getMaxEnergyStored(), false);
+        fill(energyStorage);
         list.add(full);
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockEnergyBattery.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockEnergyBattery.java
@@ -73,10 +73,7 @@ public class BlockEnergyBattery extends BlockEnergyBatteryBase {
             IEnergyStorageCapacity energyStorage = (IEnergyStorageCapacity) currentStack.getCapability(CapabilityEnergy.ENERGY, null);
             energyStorage.setCapacity(capacity);
             list.add(currentStack.copy());
-            int stored = 1;
-            while (stored > 0) {
-                stored = energyStorage.receiveEnergy(capacity, false);
-            }
+            fill(energyStorage);
             list.add(currentStack.copy());
             lastCapacity = capacity;
             capacity = capacity << 2;

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockEnergyBatteryBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockEnergyBatteryBase.java
@@ -8,6 +8,7 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
+import net.minecraftforge.energy.IEnergyStorage;
 import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.cyclopscore.helper.TileHelpers;
@@ -62,5 +63,17 @@ public abstract class BlockEnergyBatteryBase extends BlockContainerCabled implem
             }
         }
         return false;
+    }
+
+    /**
+     * Fill an IEnergyStorage with all the energy it can hold
+     * @param energyStorage IEnergyStorage that is to be filled
+     */
+    public static void fill(IEnergyStorage energyStorage){
+        int max = energyStorage.getMaxEnergyStored();
+        int stored = 1;
+        while (stored > 0) {
+            stored = energyStorage.receiveEnergy(max, false);
+        }
     }
 }


### PR DESCRIPTION
Fixes the last failing integration test:
![image](https://user-images.githubusercontent.com/17239590/36647675-924bb9dc-1a46-11e8-8058-ed7d72658e7e.png)


The root problem was also resulting in the creative energy battery not appearing to be full in the creative tab:
![image](https://user-images.githubusercontent.com/17239590/36647678-a0f23ff6-1a46-11e8-9d1c-a49983496857.png)

And the fixed version in this PR:
![image](https://user-images.githubusercontent.com/17239590/36647684-b5b61bf6-1a46-11e8-84cf-9b68d7a1f96a.png)

