### PR TITLE
Fix the creative energy battery acting like a regular energy battery when in item form

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/capability/energystorage/EnergyStorageItemBlockEnergyContainer.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/energystorage/EnergyStorageItemBlockEnergyContainer.java
@@ -3,7 +3,9 @@ package org.cyclops.integrateddynamics.capability.energystorage;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import org.cyclops.cyclopscore.helper.ItemStackHelpers;
+import org.cyclops.integrateddynamics.block.BlockEnergyBatteryBase;
 import org.cyclops.integrateddynamics.block.BlockEnergyBatteryConfig;
+import org.cyclops.integrateddynamics.block.IEnergyContainerBlock;
 import org.cyclops.integrateddynamics.core.item.ItemBlockEnergyContainer;
 
 /**
@@ -30,14 +32,21 @@ public class EnergyStorageItemBlockEnergyContainer implements IEnergyStorageCapa
         return rate;
     }
 
+    public boolean isCreative() {
+        IEnergyContainerBlock block = itemBlockEnergyContainer.get();
+        return block instanceof BlockEnergyBatteryBase && ((BlockEnergyBatteryBase) block).isCreative();
+    }
+
     @Override
     public int getEnergyStored() {
+        if(isCreative()) return Integer.MAX_VALUE;
         NBTTagCompound tag = ItemStackHelpers.getSafeTagCompound(itemStack);
         return tag.getInteger(itemBlockEnergyContainer.get().getEneryContainerNBTName());
     }
 
     @Override
     public int getMaxEnergyStored() {
+        if(isCreative()) return Integer.MAX_VALUE;
         NBTTagCompound tag = ItemStackHelpers.getSafeTagCompound(itemStack);
         if (!tag.hasKey(itemBlockEnergyContainer.get().getEneryContainerCapacityNBTName())) {
             return BlockEnergyBatteryConfig.capacity;
@@ -57,6 +66,7 @@ public class EnergyStorageItemBlockEnergyContainer implements IEnergyStorageCapa
 
     @Override
     public int receiveEnergy(int energy, boolean simulate) {
+        if(isCreative()) return 0;
         energy = Math.min(energy, getRate());
         int stored = getEnergyStored();
         int energyReceived = Math.min(getMaxEnergyStored() - stored, energy);
@@ -68,6 +78,7 @@ public class EnergyStorageItemBlockEnergyContainer implements IEnergyStorageCapa
 
     @Override
     public int extractEnergy(int energy, boolean simulate) {
+        if(isCreative()) return energy;
         energy = Math.min(energy, getRate());
         int stored = getEnergyStored();
         int newEnergy = Math.max(stored - energy, 0);
@@ -78,6 +89,7 @@ public class EnergyStorageItemBlockEnergyContainer implements IEnergyStorageCapa
     }
 
     protected void setEnergy(ItemStack itemStack, int energy) {
+        if(isCreative()) return;
         NBTTagCompound tag = ItemStackHelpers.getSafeTagCompound(itemStack);
         tag.setInteger(itemBlockEnergyContainer.get().getEneryContainerNBTName(), energy);
     }


### PR DESCRIPTION
This mirrors what TileEnergyBattery already does.