### PR TITLE
PartNetworkElement: small performance tweak

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/network/PartNetworkElement.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/PartNetworkElement.java
@@ -206,9 +206,9 @@ public class PartNetworkElement<P extends IPartType<P, S>, S extends IPartState<
 
     @Override
     public int compareTo(INetworkElement o) {
-        if(o instanceof IPartNetworkElement) {
+        if (o instanceof IPartNetworkElement) {
             IPartNetworkElement p = (IPartNetworkElement) o;
-            int compClass = this.getPart().getClass().getCanonicalName().compareTo(p.getPart().getClass().getCanonicalName());
+            int compClass = this.getPart().getName().compareTo(p.getPart().getName());
             if (compClass == 0) {
                 // If this or the other part is not loaded, we IGNORE the priority,
                 // because that depends on tile entity data, which requires loading the part/chunk.
@@ -230,7 +230,8 @@ public class PartNetworkElement<P extends IPartType<P, S>, S extends IPartState<
                 return compClass;
             }
         }
-        return this.getClass().getCanonicalName().compareTo(o.getClass().getCanonicalName());
+
+        return this.getClass().getName().compareTo(o.getClass().getName());
     }
 
     @Override


### PR DESCRIPTION
when profiling my server, 17% of total time (not CPU time, so it might actually be worse) was spend in the `getOrDefault` and `put` functions of the `updateableElementsTicks` map in the `Network` class as (function calls can be seen here [Network.java#L404](https://github.com/CyclopsMC/IntegratedDynamics/blob/master-1.12/src/main/java/org/cyclops/integrateddynamics/core/network/Network.java#L404))
 
this in part was because of the constant calling to `compareTo` in the `PartNetworkElement` (it's a TreeMap, so it's using sorting for placement yada yada) most of this time (7%~) was spend in `.getClass().getCanonicalName()`, every time this function is called it reconstructs the name without caching making it very slow, so I have replaced those with `.getName()` (parts have a unique name per component) and `.getClass().getName()` which is unique enough for this use case and is cached, so the string building overhead is gone.

currently running my server with this patch applied, the CPU time of `getOrDefault` and `put` has now been reduced to 2.1%