### PR TITLE
Network diagnostic tool: cleanup and bugfixes

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/GuiNetworkDiagnostics.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/GuiNetworkDiagnostics.java
@@ -269,6 +269,7 @@ public class GuiNetworkDiagnostics extends JFrame {
                                         ObservablePartData partData = getPartDataFromRow(row);
                                         if (partData != null) {
                                             teleportPlayer(e, partData.toPartPos());
+                                            ((DefaultTableModel) target.getModel()).fireTableRowsUpdated(row, row);
                                         }
                                     }
                                 }
@@ -330,6 +331,7 @@ public class GuiNetworkDiagnostics extends JFrame {
                                         ObservableObserverData observerData = getObserverDataFromRow(row);
                                         if (observerData != null) {
                                             teleportPlayer(e, observerData.toPartPos());
+                                            ((DefaultTableModel) target.getModel()).fireTableRowsUpdated(row, row);
                                         }
                                     }
                                 }
@@ -427,6 +429,9 @@ public class GuiNetworkDiagnostics extends JFrame {
     }
 
     private static void teleportPlayer(MouseEvent e, PartPos pos) {
+        if (pos == null) {
+            return;
+        }
         if (e.getButton() == MouseEvent.BUTTON1) {
             if (NetworkDiagnosticsPartOverlayRenderer.getInstance().hasPartPos(pos)) {
                 NetworkDiagnosticsPartOverlayRenderer.getInstance().removePos(pos);
@@ -434,8 +439,12 @@ public class GuiNetworkDiagnostics extends JFrame {
                 NetworkDiagnosticsPartOverlayRenderer.getInstance().addPos(pos);
             }
         } else if (e.getButton() == MouseEvent.BUTTON3) {
-            BlockPos blockPos = pos.getPos().getBlockPos().offset(pos.getSide());
-            float yaw = pos.getSide().getOpposite().getHorizontalAngle();
+            BlockPos blockPos = pos.getPos().getBlockPos();
+            float yaw = 0;
+            if (pos.getSide() != null) {
+                blockPos = blockPos.offset(pos.getSide());
+                yaw = pos.getSide().getOpposite().getHorizontalAngle();
+            }
             IntegratedDynamics._instance.getPacketHandler().sendToServer(new PlayerTeleportPacket(
                     pos.getPos().getDimensionId(),
                     blockPos.getX(),

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/GuiNetworkDiagnostics.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/GuiNetworkDiagnostics.java
@@ -37,19 +37,34 @@ import java.util.Vector;
  */
 public class GuiNetworkDiagnostics extends JFrame {
 
+    private static final int IDX_PARTS_NETWORK = 0;
+    private static final int IDX_PARTS_CABLES = 1;
+    private static final int IDX_PARTS_PART = 2;
+    private static final int IDX_PARTS_TICKTIME = 3;
+    private static final int IDX_PARTS_DIMENSION = 4;
+    private static final int IDX_PARTS_POSITION = 5;
+    private static final int IDX_PARTS_SIDE = 6;
+    private static final int IDX_PARTS_ID = 7;
+
+    private static final int IDX_OBSERVERS_NETWORK = 0;
+    private static final int IDX_OBSERVERS_PART = 1;
+    private static final int IDX_OBSERVERS_TICKTIME = 2;
+    private static final int IDX_OBSERVERS_DIMENSION = 3;
+    private static final int IDX_OBSERVERS_POSITION = 4;
+    private static final int IDX_OBSERVERS_SIDE = 5;
+    private static final int IDX_OBSERVERS_ID = 6;
+
     private static GuiNetworkDiagnostics gui = null;
 
     private static JTable tableParts = null;
-    private static Vector<String> columnNamesParts = new Vector<>();
-    private static Vector<Vector<Object>> dataParts = new Vector<>();
-    private static DefaultTableModel modelParts;
-    private static Multimap<Integer, ObservablePartData> networkDataParts = ArrayListMultimap.create();
+    private static final Vector<String> columnNamesParts = new Vector<>();
+    private static final Vector<Vector<Object>> dataParts = new Vector<>();
+    private static final Multimap<Integer, ObservablePartData> networkDataParts = ArrayListMultimap.create();
 
     private static JTable tableObservers = null;
-    private static Vector<String> columnNamesObservers = new Vector<>();
-    private static Vector<Vector<Object>> dataObservers = new Vector<>();
-    private static DefaultTableModel modelObservers;
-    private static Multimap<Integer, ObservableObserverData> networkDataObservers = ArrayListMultimap.create();
+    private static final Vector<String> columnNamesObservers = new Vector<>();
+    private static final Vector<Vector<Object>> dataObservers = new Vector<>();
+    private static final Multimap<Integer, ObservableObserverData> networkDataObservers = ArrayListMultimap.create();
 
     public static void setNetworkData(int id, RawNetworkData rawNetworkData) {
         synchronized (networkDataParts) {
@@ -152,28 +167,17 @@ public class GuiNetworkDiagnostics extends JFrame {
                     super.windowClosing(e);
                 }
             });
-            gui.setLocationRelativeTo((Component) null);
+            gui.setLocationRelativeTo(null);
         }
         gui.setVisible(true);
     }
 
-    protected void updateTables() {
+    private void updateTables() {
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override
                 public void run() {
                     synchronized (networkDataParts) {
-                        /* ----- ----- ----- Init parts table ----- ----- ----- */
-                        columnNamesParts.clear();
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.network"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.cables"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.part"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.ticktime"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.dimension"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.position"));
-                        columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.side"));
-                        columnNamesParts.addElement("_id");
-
                         dataParts.clear();
                         int i = 0;
                         for (ObservablePartData observablePartData : networkDataParts.values()) {
@@ -206,22 +210,40 @@ public class GuiNetworkDiagnostics extends JFrame {
                         }
 
                         if (tableParts == null) {
-                            tableParts = new JTable();
-                            modelParts = new DefaultTableModel(dataParts, columnNamesParts) {
+                            /* ----- ----- ----- Init parts table ----- ----- ----- */
+                            columnNamesParts.clear();
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.network"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.cables"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.part"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.ticktime"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.dimension"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.position"));
+                            columnNamesParts.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.side"));
+                            columnNamesParts.addElement("_id");
+
+                            tableParts = new JTable(new DefaultTableModel(dataParts, columnNamesParts) {
                                 @Override
                                 public Class<?> getColumnClass(int column) {
                                     // My eyes are bleeding as I write this...
                                     // I'm terribly sorry, I must be going to hell now.
-                                    if (column == 0 || column == 1 || column == 4) {
-                                        return Integer.class;
+                                    switch (column) {
+                                        case IDX_PARTS_NETWORK:
+                                        case IDX_PARTS_CABLES:
+                                        case IDX_PARTS_DIMENSION:
+                                            return Integer.class;
+
+                                        case IDX_PARTS_TICKTIME:
+                                            return Long.class;
+
+                                        case IDX_PARTS_PART:
+                                        case IDX_PARTS_POSITION:
+                                        case IDX_PARTS_SIDE:
+                                        default:
+                                            return String.class;
                                     }
-                                    if (column == 3) {
-                                        return Long.class;
-                                    }
-                                    return String.class;
                                 }
-                            };
-                            tableParts.setModel(modelParts);
+                            });
+
                             tableParts.setDefaultRenderer(String.class, new DefaultTableCellRenderer() {
                                 @Override
                                 public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
@@ -235,8 +257,6 @@ public class GuiNetworkDiagnostics extends JFrame {
                                     return c;
                                 }
                             });
-                            tableParts.getColumnModel().removeColumn(tableParts.getColumn("_id"));
-                            tableParts.setAutoCreateRowSorter(true);
                             tableParts.addMouseListener(new MouseAdapter() {
                                 @Override
                                 public void mouseClicked(MouseEvent e) {
@@ -246,14 +266,13 @@ public class GuiNetworkDiagnostics extends JFrame {
                                         int row = target.rowAtPoint(e.getPoint());
                                         ObservablePartData partData = getPartDataFromRow(row);
                                         if (partData != null) {
-                                            PartPos pos = partData.toPartPos();
                                             teleportPlayer(e, partData.toPartPos());
                                         }
                                     }
                                 }
                             });
 
-                            /* ----- ----- ----- Init parts table ----- ----- ----- */
+                            /* ----- ----- ----- Init observers table ----- ----- ----- */
                             columnNamesObservers.clear();
                             columnNamesObservers.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.network"));
                             columnNamesObservers.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.part"));
@@ -263,43 +282,34 @@ public class GuiNetworkDiagnostics extends JFrame {
                             columnNamesObservers.addElement(L10NHelpers.localize("gui.integrateddynamics.diagnostics.table.side"));
                             columnNamesObservers.addElement("_id");
 
-                            dataObservers.clear();
-                            i = 0;
-                            for (ObservableObserverData observablePartData : networkDataObservers.values()) {
-                                Vector<Object> row = new Vector<>();
-                                row.add(observablePartData.getNetworkId());
-                                row.add(observablePartData.getName());
-                                row.add(String.format("%.6f", ((double) observablePartData.getLast20TicksDurationNs()) / MinecraftHelpers.SECOND_IN_TICKS / 1000000));
-                                row.add(observablePartData.getDimension());
-                                BlockPos pos = observablePartData.getPos();
-                                row.add(String.format("%s / %s / %s", pos.getX(), pos.getY(), pos.getZ()));
-                                row.add(observablePartData.getSide().name());
-                                row.add(i++);
-                                dataObservers.addElement(row);
-                            }
-
-                            tableObservers = new JTable();
-                            modelObservers = new DefaultTableModel(dataObservers, columnNamesObservers) {
+                            tableObservers = new JTable(new DefaultTableModel(dataObservers, columnNamesObservers) {
                                 @Override
                                 public Class<?> getColumnClass(int column) {
                                     // My eyes are bleeding as I write this...
                                     // I'm terribly sorry, I must be going to hell now.
-                                    if (column == 0 || column == 3) {
-                                        return Integer.class;
+                                    switch (column) {
+                                        case IDX_OBSERVERS_NETWORK:
+                                        case IDX_OBSERVERS_DIMENSION:
+                                            return Integer.class;
+
+                                        case IDX_OBSERVERS_TICKTIME:
+                                            return Long.class;
+
+                                        case IDX_OBSERVERS_PART:
+                                        case IDX_OBSERVERS_POSITION:
+                                        case IDX_OBSERVERS_SIDE:
+                                        default:
+                                            return String.class;
                                     }
-                                    if (column == 2) {
-                                        return Long.class;
-                                    }
-                                    return String.class;
                                 }
-                            };
-                            tableObservers.setModel(modelObservers);
+                            });
+
                             tableObservers.setDefaultRenderer(String.class, new DefaultTableCellRenderer() {
                                 @Override
                                 public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
                                     Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-                                    ObservableObserverData partData = getObserverDataFromRow(row);
-                                    if (partData != null && NetworkDiagnosticsPartOverlayRenderer.getInstance().hasPartPos(partData.toPartPos())) {
+                                    ObservableObserverData observerData = getObserverDataFromRow(row);
+                                    if (observerData != null && NetworkDiagnosticsPartOverlayRenderer.getInstance().hasPartPos(observerData.toPartPos())) {
                                         c.setBackground(Color.CYAN);
                                     } else {
                                         c.setBackground(isSelected ? Color.BLUE : Color.WHITE);
@@ -307,8 +317,6 @@ public class GuiNetworkDiagnostics extends JFrame {
                                     return c;
                                 }
                             });
-                            tableObservers.getColumnModel().removeColumn(tableObservers.getColumn("_id"));
-                            tableObservers.setAutoCreateRowSorter(true);
                             tableObservers.addMouseListener(new MouseAdapter() {
                                 @Override
                                 public void mouseClicked(MouseEvent e) {
@@ -316,13 +324,18 @@ public class GuiNetworkDiagnostics extends JFrame {
                                     if (e.getClickCount() == 1) {
                                         JTable target = (JTable)e.getSource();
                                         int row = target.rowAtPoint(e.getPoint());
-                                        ObservableObserverData partData = getObserverDataFromRow(row);
-                                        if (partData != null) {
-                                            teleportPlayer(e, partData.toPartPos());
+                                        ObservableObserverData observerData = getObserverDataFromRow(row);
+                                        if (observerData != null) {
+                                            teleportPlayer(e, observerData.toPartPos());
                                         }
                                     }
                                 }
                             });
+
+                            for (JTable table : new JTable[] { tableParts, tableObservers }) {
+                                table.getColumnModel().removeColumn(table.getColumn("_id"));
+                                table.setAutoCreateRowSorter(true);
+                            }
 
                             // Pack GUI
                             JPanel panelMain = new JPanel(new GridLayout(2, 1));
@@ -338,9 +351,9 @@ public class GuiNetworkDiagnostics extends JFrame {
                             pack();
                         } else {
                             tableParts.getRowSorter().allRowsChanged();
-                            modelParts.fireTableDataChanged();
+                            ((DefaultTableModel) tableParts.getModel()).fireTableDataChanged();
                             tableObservers.getRowSorter().allRowsChanged();
-                            modelObservers.fireTableDataChanged();
+                            ((DefaultTableModel) tableObservers.getModel()).fireTableDataChanged();
                         }
                         repaint();
                     }
@@ -351,7 +364,7 @@ public class GuiNetworkDiagnostics extends JFrame {
         }
     }
 
-    protected static ObservablePartData getPartDataFromRow(int row) {
+    private static ObservablePartData getPartDataFromRow(int row) {
         if (row < 0) {
             return null;
         }
@@ -359,14 +372,14 @@ public class GuiNetworkDiagnostics extends JFrame {
         synchronized (networkDataParts) {
             data = networkDataParts.values().toArray();
         }
-        int internalId = (int) tableParts.getModel().getValueAt(tableParts.convertRowIndexToModel(row), 7);
+        int internalId = (int) tableParts.getModel().getValueAt(tableParts.convertRowIndexToModel(row), IDX_PARTS_ID);
         if (internalId < data.length) {
             return (ObservablePartData) data[internalId];
         }
         return null;
     }
 
-    protected static ObservableObserverData getObserverDataFromRow(int row) {
+    private static ObservableObserverData getObserverDataFromRow(int row) {
         if (row < 0) {
             return null;
         }
@@ -374,19 +387,19 @@ public class GuiNetworkDiagnostics extends JFrame {
         synchronized (networkDataParts) {
             data = networkDataObservers.values().toArray();
         }
-        int internalId = (int) tableObservers.getModel().getValueAt(tableObservers.convertRowIndexToModel(row), 6);
+        int internalId = (int) tableObservers.getModel().getValueAt(tableObservers.convertRowIndexToModel(row), IDX_OBSERVERS_ID);
         if (internalId < data.length) {
             return (ObservableObserverData) data[internalId];
         }
         return null;
     }
 
-    protected static void onCloseGui() {
+    private static void onCloseGui() {
         IntegratedDynamics._instance.getPacketHandler().sendToServer(NetworkDiagnosticsSubscribePacket.unsubscribe());
         NetworkDiagnosticsPartOverlayRenderer.getInstance().clearPositions();
     }
 
-    protected static void teleportPlayer(MouseEvent e, PartPos pos) {
+    private static void teleportPlayer(MouseEvent e, PartPos pos) {
         if (e.getButton() == MouseEvent.BUTTON1) {
             if (NetworkDiagnosticsPartOverlayRenderer.getInstance().hasPartPos(pos)) {
                 NetworkDiagnosticsPartOverlayRenderer.getInstance().removePos(pos);
@@ -408,7 +421,7 @@ public class GuiNetworkDiagnostics extends JFrame {
     }
 
     @Data
-    public static class ObservablePartData {
+    private static class ObservablePartData {
         private final int networkId;
         private final int networkCables;
         private final int dimension;
@@ -417,7 +430,7 @@ public class GuiNetworkDiagnostics extends JFrame {
         private final String name;
         private final long last20TicksDurationNs;
 
-        public PartPos toPartPos() {
+        private PartPos toPartPos() {
             World world = Minecraft.getMinecraft().world;
             if (getDimension() == world.provider.getDimension()) {
                 return PartPos.of(DimPos.of(world, getPos()), getSide());
@@ -427,7 +440,7 @@ public class GuiNetworkDiagnostics extends JFrame {
     }
 
     @Data
-    public static class ObservableObserverData {
+    private static class ObservableObserverData {
         private final int networkId;
         private final int dimension;
         private final BlockPos pos;
@@ -435,7 +448,7 @@ public class GuiNetworkDiagnostics extends JFrame {
         private final String name;
         private final long last20TicksDurationNs;
 
-        public PartPos toPartPos() {
+        private PartPos toPartPos() {
             World world = Minecraft.getMinecraft().world;
             if (getDimension() == world.provider.getDimension()) {
                 return PartPos.of(DimPos.of(world, getPos()), getSide());

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/NetworkDiagnosticsPartOverlayRenderer.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/NetworkDiagnosticsPartOverlayRenderer.java
@@ -2,6 +2,7 @@ package org.cyclops.integrateddynamics.core.network.diagnostics;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderGlobal;
@@ -68,13 +69,19 @@ public class NetworkDiagnosticsPartOverlayRenderer {
             for (PartPos partPos : partList) {
                 if (partPos.getPos().getDimensionId() == player.world.provider.getDimension() && partPos.getPos().getBlockPos().distanceSq(player.getPosition()) < 10000) {
                     PartHelpers.PartStateHolder<?, ?> partStateHolder = PartHelpers.getPart(partPos);
+                    final AxisAlignedBB localPartBB;
                     if (partStateHolder != null) {
-                        final AxisAlignedBB globalRenderBB = partStateHolder.getPart().getPartRenderPosition().getBoundingBox(partPos.getSide())
-                                .offset(partPos.getPos().getBlockPos())
-                                .offset(-offsetX, -offsetY, -offsetZ)
-                                .expand(0.05, 0.05, 0.05);
-                        RenderGlobal.drawSelectionBoundingBox(globalRenderBB, 1.0F, 0.2F, 0.1F, 0.8F);
+                        localPartBB = partStateHolder.getPart().getPartRenderPosition().getBoundingBox(partPos.getSide());
+                    } else {
+                        localPartBB = Block.FULL_BLOCK_AABB;
                     }
+
+                    final AxisAlignedBB globalRenderBB = localPartBB
+                            .offset(partPos.getPos().getBlockPos())
+                            .offset(-offsetX, -offsetY, -offsetZ)
+                            .expand(0.05, 0.05, 0.05)
+                            .expand(-0.05, -0.05, -0.05);
+                    RenderGlobal.drawSelectionBoundingBox(globalRenderBB, 1.0F, 0.2F, 0.1F, 0.8F);
                 }
             }
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/NetworkDiagnosticsPartOverlayRenderer.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/diagnostics/NetworkDiagnosticsPartOverlayRenderer.java
@@ -65,18 +65,15 @@ public class NetworkDiagnosticsPartOverlayRenderer {
             GlStateManager.depthMask(false);
 
             List<PartPos> partList = Lists.newArrayList(partPositions);
-            for (Iterator<PartPos> it = partList.iterator(); it.hasNext(); ) {
-                PartPos partPos = it.next();
+            for (PartPos partPos : partList) {
                 if (partPos.getPos().getDimensionId() == player.world.provider.getDimension() && partPos.getPos().getBlockPos().distanceSq(player.getPosition()) < 10000) {
                     PartHelpers.PartStateHolder<?, ?> partStateHolder = PartHelpers.getPart(partPos);
                     if (partStateHolder != null) {
-                        AxisAlignedBB bb = partStateHolder.getPart().getPartRenderPosition().getBoundingBox(partPos.getSide())
+                        final AxisAlignedBB globalRenderBB = partStateHolder.getPart().getPartRenderPosition().getBoundingBox(partPos.getSide())
                                 .offset(partPos.getPos().getBlockPos())
                                 .offset(-offsetX, -offsetY, -offsetZ)
                                 .expand(0.05, 0.05, 0.05);
-                        RenderGlobal.drawSelectionBoundingBox(bb, 1.0F, 0.2F, 0.1F, 0.8F);
-                    } else {
-                        it.remove();
+                        RenderGlobal.drawSelectionBoundingBox(globalRenderBB, 1.0F, 0.2F, 0.1F, 0.8F);
                     }
                 }
             }


### PR DESCRIPTION
The network diagnostics tables sort the tick time by string instead of by actual numerical value.
This results in 10 being sorted lower than 9, for instance.

This PR fixes that.

Before:
![image](https://user-images.githubusercontent.com/963797/70944235-f222de80-2052-11ea-81e1-2919574b87cb.png)
After:
![image](https://user-images.githubusercontent.com/963797/70944247-f5b66580-2052-11ea-9ceb-53962cb89de5.png)

I also got rid of some redundant code and a warning and made some.

~~Full disclosure: I did not test the "Storage Observers" part, since I couldn't get anything to appear there with only Integrated Dynamics and no Integrated Tunnels installed.
Apart from removing that redundant code, the changes to both tables are identical, though, so it *should* work fine. :)~~ I was able to test it using a battery and a furnace.

EDIT:
I made a lot more changes since I wrote that description.
Here's a list of all the changes, from master to current:
- 3 commits - Code quality changes
- Made the hellish `getColumnClass` override a bit less eye-bleeding
- Deduplicate code
- Made the hellish `getColumnClass` override a bit less eye-bleeding
- **Fixed the sorting by tickttime**, as mentioned above
- **Fixed the sorting by position**, too
- **Mark the entire line instead of just certain columns**
- **Use the default selection color instead of dark blue**
- Code quality changes
- **Fix teleporting to full blocks**
- Code quality changes
- Optical changes to the red box around marked components
- Code quality changes
- **Fix red box around marked full-block components**
- **Reduce visual feedback delay when marking components**