### PR TITLE
[1.16] Account for Nullable arguments in BlockCable$BlockColor#getColor

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
@@ -443,7 +443,8 @@ public class BlockCable extends BlockTile implements IDynamicModelElement, IWate
         @Override
         public int getColor(BlockState blockState, @Nullable IBlockDisplayReader world, @Nullable BlockPos blockPos, int color) {
             // Only modify color if we have a facade
-            return CableHelpers.getFacade(world, blockPos)
+            return world == null || blockPos == null ?
+                -1 : CableHelpers.getFacade(world, blockPos)
                     .map(facadeState -> Minecraft.getInstance().getBlockColors().getColor(facadeState, world, blockPos, color))
                     .orElse(-1);
         }


### PR DESCRIPTION
## Current problem

In `IBlockColor#getColor(BlockState, IBlockDisplayReader, BlockPos, int)` the second and third argument, the world and block pos, are annotated with `Nullable`. These arguments will indeed be supplied with a null value when calling for example `BlockRendererDispatcher#renderBlock`.

The implementation of `IBlockColor#getColor` in `BlockCable$BlockColor` passes the world and block pos arguments to `CableHelpers#getFacade`. `CableHelpers#getFacade` will throw a null pointer exception for a null world argument due to the first line in `TileHelpers#getSafeTile` (https://github.com/CyclopsMC/CyclopsCore/blob/41b14dfab4ede75972316d6393fbb3dc86aefaa8/src/main/java/org/cyclops/cyclopscore/helper/TileHelpers.java#L63).

## The fix in this PR

This pull request prevents the null pointer exception by checking whether the world or block pos arguments are null in `BlockCable$BlockColor#getColor` before they are passed to `CableHelpers#getFacade`.

## Example of the problem

In my mod Entangled, I render other blocks inside my own block via `BlockRendererDispatcher#renderBlock`. When trying to render a Logic Cable, it results in the exception described above.
- `latest.log` of the crash: https://gist.github.com/SuperMartijn642/bc10be92731133077dcace16ca4fca8a