### PR TITLE
#1217 Add 'fuzzy' operator, for shortening numbers to make them useful on displays.

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/GeneralConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/GeneralConfig.java
@@ -133,6 +133,21 @@ public class GeneralConfig extends DummyConfig {
     @ConfigurableProperty(category = "core", comment = "The maximum frequency at which speach messages can be played in milliseconds.", isCommandable = true, configLocation = ModConfig.Type.CLIENT)
     public static int speachMaxFrequency = 1000;
 
+    @ConfigurableProperty(category = "core" , comment = "When true, use the LONG number format style. Otherwise, use the SHORT style.")
+    public static boolean numberCompactUseLongStyle = false;
+
+    @ConfigurableProperty(category = "core" , comment = "The maximum number of fractional digits to include in the result of the compact operator")
+    public static int numberCompactMaximumFractionDigits = 2;
+
+    @ConfigurableProperty(category = "core" , comment = "The minimum number of fractional digits to include in the result of the compact operator")
+    public static int numberCompactMinimumFractionDigits = 0;
+
+    @ConfigurableProperty(category = "core" , comment = "The maximum number of integer digits to include in the result of the compact operator")
+    public static int numberCompactMaximumIntegerDigits = 3;
+
+    @ConfigurableProperty(category = "core" , comment = "The minimum number of integer digits to include in the result of the compact operator")
+    public static int numberCompactMinimumIntegerDigits = 1;
+
     public GeneralConfig() {
         super(IntegratedDynamics._instance, "general");
     }

--- a/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IValueTypeNumber.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IValueTypeNumber.java
@@ -18,7 +18,7 @@ public interface IValueTypeNumber<V extends IValue> extends IValueType<V>, IValu
     public V divide(V a, V b);
     public V max(V a, V b);
     public V min(V a, V b);
-    public ValueTypeString.ValueString fuzzy(V a);
+    public ValueTypeString.ValueString compact(V a);
     public boolean greaterThan(V a, V b);
     public boolean lessThan(V a, V b);
     public ValueTypeInteger.ValueInteger round(V a);

--- a/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IValueTypeNumber.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/evaluate/variable/IValueTypeNumber.java
@@ -1,6 +1,7 @@
 package org.cyclops.integrateddynamics.api.evaluate.variable;
 
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeInteger;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeString;
 
 /**
  * A numerical value type.
@@ -17,6 +18,7 @@ public interface IValueTypeNumber<V extends IValue> extends IValueType<V>, IValu
     public V divide(V a, V b);
     public V max(V a, V b);
     public V min(V a, V b);
+    public ValueTypeString.ValueString fuzzy(V a);
     public boolean greaterThan(V a, V b);
     public boolean lessThan(V a, V b);
     public ValueTypeInteger.ValueInteger round(V a);

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/OperatorBuilders.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/OperatorBuilders.java
@@ -112,6 +112,7 @@ public class OperatorBuilders {
     // --------------- Number builders ---------------
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> NUMBER = OperatorBuilder.forType(ValueTypes.CATEGORY_NUMBER).appendKind("number");
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> NUMBER_1_PREFIX = NUMBER.inputTypes(1, ValueTypes.CATEGORY_NUMBER).renderPattern(IConfigRenderPattern.PREFIX_1);
+    public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> NUMBER_1_LONG = NUMBER.inputTypes(1, ValueTypes.CATEGORY_NUMBER).renderPattern(IConfigRenderPattern.SUFFIX_1_LONG);
 
     // --------------- Nullable builders ---------------
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> NULLABLE = OperatorBuilder.forType(ValueTypes.CATEGORY_NULLABLE).appendKind("general");

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
@@ -823,6 +823,15 @@ public final class Operators {
             ).build());
 
     /**
+     * Accepts a number, and returns a string roughly representing that number
+     */
+    public static final IOperator NUMBER_FUZZY = REGISTRY.register(OperatorBuilders.NUMBER_1_LONG
+            .inputType(ValueTypes.CATEGORY_NUMBER).output(ValueTypes.STRING).symbolOperator("fuzzy")
+            .function(
+                variables -> ValueTypes.CATEGORY_NUMBER.fuzzy(variables.getVariables()[0])
+            ).build());
+
+    /**
      * ----------------------------------- NULLABLE OPERATORS -----------------------------------
      */
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/Operators.java
@@ -90,7 +90,6 @@ import org.cyclops.integrateddynamics.core.helper.NbtHelpers;
 import org.cyclops.integrateddynamics.core.ingredient.ExtendedIngredientsList;
 import org.cyclops.integrateddynamics.core.ingredient.ExtendedIngredientsSingle;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -825,10 +824,10 @@ public final class Operators {
     /**
      * Accepts a number, and returns a string roughly representing that number
      */
-    public static final IOperator NUMBER_FUZZY = REGISTRY.register(OperatorBuilders.NUMBER_1_LONG
-            .inputType(ValueTypes.CATEGORY_NUMBER).output(ValueTypes.STRING).symbolOperator("fuzzy")
+    public static final IOperator NUMBER_COMPACT = REGISTRY.register(OperatorBuilders.NUMBER_1_LONG
+            .inputType(ValueTypes.CATEGORY_NUMBER).output(ValueTypes.STRING).symbolOperator("compact")
             .function(
-                variables -> ValueTypes.CATEGORY_NUMBER.fuzzy(variables.getVariables()[0])
+                variables -> ValueTypes.CATEGORY_NUMBER.compact(variables.getVariables()[0])
             ).build());
 
     /**

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeCategoryNumber.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeCategoryNumber.java
@@ -178,6 +178,11 @@ public class ValueTypeCategoryNumber extends ValueTypeCategoryBase<IValue> imple
         return type.floor(castValue(type, a.getValue()));
     }
 
+    public ValueTypeString.ValueString fuzzy(IVariable a) throws EvaluationException {
+        IValueTypeNumber type = getType(a);
+        return type.fuzzy(castValue(type, a.getValue()));
+    }
+
     @Override
     public String getName(IValue a) {
         return ((IValueTypeNamed) a.getType()).getName(a);

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeCategoryNumber.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeCategoryNumber.java
@@ -178,9 +178,9 @@ public class ValueTypeCategoryNumber extends ValueTypeCategoryBase<IValue> imple
         return type.floor(castValue(type, a.getValue()));
     }
 
-    public ValueTypeString.ValueString fuzzy(IVariable a) throws EvaluationException {
+    public ValueTypeString.ValueString compact(IVariable a) throws EvaluationException {
         IValueTypeNumber type = getType(a);
-        return type.fuzzy(castValue(type, a.getValue()));
+        return type.compact(castValue(type, a.getValue()));
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeDouble.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeDouble.java
@@ -7,6 +7,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import org.cyclops.cyclopscore.helper.Helpers;
+import org.cyclops.integrateddynamics.GeneralConfig;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
@@ -129,9 +130,15 @@ public class ValueTypeDouble extends ValueTypeBase<ValueTypeDouble.ValueDouble> 
     }
 
     @Override
-    public ValueTypeString.ValueString fuzzy(ValueDouble a) {
-        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        nf.setMaximumFractionDigits(2);
+    public ValueTypeString.ValueString compact(ValueDouble a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(
+            Locale.US,
+            GeneralConfig.numberCompactUseLongStyle ? NumberFormat.Style.LONG : NumberFormat.Style.SHORT
+        );
+        nf.setMinimumFractionDigits(GeneralConfig.numberCompactMinimumFractionDigits);
+        nf.setMaximumFractionDigits(GeneralConfig.numberCompactMaximumFractionDigits);
+        nf.setMinimumIntegerDigits(GeneralConfig.numberCompactMinimumIntegerDigits);
+        nf.setMaximumIntegerDigits(GeneralConfig.numberCompactMaximumIntegerDigits);
         return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeDouble.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeDouble.java
@@ -11,6 +11,9 @@ import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 /**
  * Value type with values that are doubles.
  * @author rubensworks
@@ -123,6 +126,13 @@ public class ValueTypeDouble extends ValueTypeBase<ValueTypeDouble.ValueDouble> 
     @Override
     public ValueTypeInteger.ValueInteger floor(ValueDouble a) {
         return ValueTypeInteger.ValueInteger.of((int) Math.floor(a.getRawValue()));
+    }
+
+    @Override
+    public ValueTypeString.ValueString fuzzy(ValueDouble a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        nf.setMaximumFractionDigits(2);
+        return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeInteger.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeInteger.java
@@ -11,6 +11,9 @@ import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 /**
  * Value type with values that are integers.
  * The raw value is nullable.
@@ -124,6 +127,13 @@ public class ValueTypeInteger extends ValueTypeBase<ValueTypeInteger.ValueIntege
     @Override
     public ValueInteger floor(ValueInteger a) {
         return a;
+    }
+
+    @Override
+    public ValueTypeString.ValueString fuzzy(ValueInteger a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        nf.setMaximumFractionDigits(2);
+        return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeInteger.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeInteger.java
@@ -7,6 +7,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import org.cyclops.cyclopscore.helper.Helpers;
+import org.cyclops.integrateddynamics.GeneralConfig;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
@@ -130,9 +131,15 @@ public class ValueTypeInteger extends ValueTypeBase<ValueTypeInteger.ValueIntege
     }
 
     @Override
-    public ValueTypeString.ValueString fuzzy(ValueInteger a) {
-        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        nf.setMaximumFractionDigits(2);
+    public ValueTypeString.ValueString compact(ValueInteger a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(
+            Locale.US,
+            GeneralConfig.numberCompactUseLongStyle ? NumberFormat.Style.LONG : NumberFormat.Style.SHORT
+        );
+        nf.setMinimumFractionDigits(GeneralConfig.numberCompactMinimumFractionDigits);
+        nf.setMaximumFractionDigits(GeneralConfig.numberCompactMaximumFractionDigits);
+        nf.setMinimumIntegerDigits(GeneralConfig.numberCompactMinimumIntegerDigits);
+        nf.setMaximumIntegerDigits(GeneralConfig.numberCompactMaximumIntegerDigits);
         return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeLong.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeLong.java
@@ -11,6 +11,9 @@ import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 /**
  * Value type with values that are doubles.
  * @author rubensworks
@@ -123,6 +126,13 @@ public class ValueTypeLong extends ValueTypeBase<ValueTypeLong.ValueLong> implem
     @Override
     public ValueTypeInteger.ValueInteger floor(ValueLong a) {
         return ValueTypeInteger.ValueInteger.of((int) a.getRawValue());
+    }
+
+    @Override
+    public ValueTypeString.ValueString fuzzy(ValueLong a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        nf.setMaximumFractionDigits(2);
+        return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeLong.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/variable/ValueTypeLong.java
@@ -7,6 +7,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import org.cyclops.cyclopscore.helper.Helpers;
+import org.cyclops.integrateddynamics.GeneralConfig;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueTypeNumber;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
@@ -129,9 +130,15 @@ public class ValueTypeLong extends ValueTypeBase<ValueTypeLong.ValueLong> implem
     }
 
     @Override
-    public ValueTypeString.ValueString fuzzy(ValueLong a) {
-        NumberFormat nf = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        nf.setMaximumFractionDigits(2);
+    public ValueTypeString.ValueString compact(ValueLong a) {
+        NumberFormat nf = NumberFormat.getCompactNumberInstance(
+            Locale.US,
+            GeneralConfig.numberCompactUseLongStyle ? NumberFormat.Style.LONG : NumberFormat.Style.SHORT
+        );
+        nf.setMinimumFractionDigits(GeneralConfig.numberCompactMinimumFractionDigits);
+        nf.setMaximumFractionDigits(GeneralConfig.numberCompactMaximumFractionDigits);
+        nf.setMinimumIntegerDigits(GeneralConfig.numberCompactMinimumIntegerDigits);
+        nf.setMaximumIntegerDigits(GeneralConfig.numberCompactMaximumIntegerDigits);
         return ValueTypeString.ValueString.of(nf.format(a.getRawValue()));
     }
 

--- a/src/main/resources/assets/integrateddynamics/lang/en_us.json
+++ b/src/main/resources/assets/integrateddynamics/lang/en_us.json
@@ -1039,8 +1039,8 @@
     "operator.integrateddynamics.number.ceil.info": "Round up to the nearest Integer",
     "operator.integrateddynamics.number.floor": "Floor",
     "operator.integrateddynamics.number.floor.info": "Round down to the nearest Integer",
-    "operator.integrateddynamics.number.fuzzy": "Fuzzy",
-    "operator.integrateddynamics.number.fuzzy.info": "Show a shorter, less precise representation of a Number",
+    "operator.integrateddynamics.number.compact": "Compact",
+    "operator.integrateddynamics.number.compact.info": "Show a shorter, less precise representation of a Number",
 
     "operator.integrateddynamics.list": "List",
     "operator.integrateddynamics.list.basename": "List %s",

--- a/src/main/resources/assets/integrateddynamics/lang/en_us.json
+++ b/src/main/resources/assets/integrateddynamics/lang/en_us.json
@@ -1039,6 +1039,8 @@
     "operator.integrateddynamics.number.ceil.info": "Round up to the nearest Integer",
     "operator.integrateddynamics.number.floor": "Floor",
     "operator.integrateddynamics.number.floor.info": "Round down to the nearest Integer",
+    "operator.integrateddynamics.number.fuzzy": "Fuzzy",
+    "operator.integrateddynamics.number.fuzzy.info": "Show a shorter, less precise representation of a Number",
 
     "operator.integrateddynamics.list": "List",
     "operator.integrateddynamics.list.basename": "List %s",

--- a/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestNumberOperators.java
+++ b/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestNumberOperators.java
@@ -170,17 +170,17 @@ public class TestNumberOperators {
      * ----------------------------------- FUZZY -----------------------------------
      */
     @Test
-    public void testIntegerFuzzy() throws EvaluationException {
-        IValue res1 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{d0});
-        assertThat("fuzzy(0) = 0", ((ValueTypeString.ValueString) res1).getRawValue(), is("0"));
+    public void testNumberCompact() throws EvaluationException {
+        IValue res1 = Operators.NUMBER_COMPACT.evaluate(new IVariable[]{d0});
+        assertThat("compact(0) = 0", ((ValueTypeString.ValueString) res1).getRawValue(), is("0"));
 
-        IValue res2 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i10});
-        assertThat("fuzzy(10) = 10", ((ValueTypeString.ValueString) res2).getRawValue(), is("10"));
+        IValue res2 = Operators.NUMBER_COMPACT.evaluate(new IVariable[]{i10});
+        assertThat("compact(10) = 10", ((ValueTypeString.ValueString) res2).getRawValue(), is("10"));
 
-        IValue res3 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i1k});
-        assertThat("fuzzy(1000) = 1K", ((ValueTypeString.ValueString) res3).getRawValue(), is("1K"));
+        IValue res3 = Operators.NUMBER_COMPACT.evaluate(new IVariable[]{i1k});
+        assertThat("compact(1000) = 1K", ((ValueTypeString.ValueString) res3).getRawValue(), is("1K"));
 
-        IValue res4 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i1m});
-        assertThat("fuzzy(1000000) = 1M", ((ValueTypeString.ValueString) res4).getRawValue(), is("1M"));
+        IValue res4 = Operators.NUMBER_COMPACT.evaluate(new IVariable[]{i1m});
+        assertThat("compact(1000000) = 1M", ((ValueTypeString.ValueString) res4).getRawValue(), is("1M"));
     }
 }

--- a/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestNumberOperators.java
+++ b/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestNumberOperators.java
@@ -26,8 +26,9 @@ public class TestNumberOperators {
     private DummyVariableDouble d0P5;
     private DummyVariableDouble d0P1;
     private DummyVariableDouble d0P9;
-
     private DummyVariableInteger i10;
+    private DummyVariableInteger i1k;
+    private DummyVariableInteger i1m;
 
     @Before
     public void before() {
@@ -38,6 +39,8 @@ public class TestNumberOperators {
         d0P9 = new DummyVariableDouble(ValueTypeDouble.ValueDouble.of(0.9));
 
         i10 = new DummyVariableInteger(ValueTypeInteger.ValueInteger.of(10));
+        i1k = new DummyVariableInteger(ValueTypeInteger.ValueInteger.of(1000));
+        i1m = new DummyVariableInteger(ValueTypeInteger.ValueInteger.of(1000000));
     }
 
     /**
@@ -163,4 +166,21 @@ public class TestNumberOperators {
         Operators.NUMBER_FLOOR.evaluate(new IVariable[]{DUMMY_VARIABLE});
     }
 
+    /**
+     * ----------------------------------- FUZZY -----------------------------------
+     */
+    @Test
+    public void testIntegerFuzzy() throws EvaluationException {
+        IValue res1 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{d0});
+        assertThat("fuzzy(0) = 0", ((ValueTypeString.ValueString) res1).getRawValue(), is("0"));
+
+        IValue res2 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i10});
+        assertThat("fuzzy(10) = 10", ((ValueTypeString.ValueString) res2).getRawValue(), is("10"));
+
+        IValue res3 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i1k});
+        assertThat("fuzzy(1000) = 1K", ((ValueTypeString.ValueString) res3).getRawValue(), is("1K"));
+
+        IValue res4 = Operators.NUMBER_FUZZY.evaluate(new IVariable[]{i1m});
+        assertThat("fuzzy(1000000) = 1M", ((ValueTypeString.ValueString) res4).getRawValue(), is("1M"));
+    }
 }


### PR DESCRIPTION
I've seen this feature request thrown around discord a bit, and figured it'd be a nice one to introduce myself to this codebase.

I (probably) haven't discussed with with the lead developers, as advised by the readme, but seeing as this wasn't a large task I figure we can start this decision here :smile: 

What languages are people expected to support out of the box, as I personally am under qualified to give a meaningful translation to non-english (and I wouldn't presume to just use google translate and hope for the best, unless that's your advice...)

![image](https://user-images.githubusercontent.com/286341/194686435-e2a3c3e6-61cf-4ae7-a1ad-4fa7d14c7801.png)
