### PR TITLE
Fix feature order in meneglin.json to resolve feature cycle issue

### DIFF
--- a/src/main/resources/data/integrateddynamics/worldgen/biome/meneglin.json
+++ b/src/main/resources/data/integrateddynamics/worldgen/biome/meneglin.json
@@ -80,16 +80,13 @@
     ],
     [
       "minecraft:glow_lichen",
-
-
-
+      "minecraft:trees_badlands",
       "minecraft:patch_grass_forest",
       "minecraft:brown_mushroom_normal",
       "minecraft:red_mushroom_normal",
       "minecraft:patch_sugar_cane",
       "minecraft:patch_pumpkin",
-
-      "minecraft:trees_badlands",
+      
       "integrateddynamics:tree_menril_meneglin",
       "integrateddynamics:flowers_meneglin"
     ],


### PR DESCRIPTION
This pull request fixes a feature cycle issue in the Integrated Dynamics mod's meneglin biome configuration. The changes ensure that the feature order closely matches the vanilla order and resolves the following error:

```
---- Minecraft Crash Report ----
// Embeddium instance tainted by mods: [movingelevators, oculus, embeddium_extra]
// Please do not reach out for Embeddium support without removing these mods first.
// -------
// Who set us up the TNT?

Time: 2024-07-31 21:40:45
Description: Exception generating new chunk

com.alcatrazescapee.cyanide.codec.FeatureCycleDetector$FeatureCycleException: A feature cycle was found.

Cycle:
At step 9
Feature 'minecraft:patch_grass_badlands'
  must be before 'minecraft:brown_mushroom_normal' (defined in 'minecraft:deep_lukewarm_ocean' at index 3, 4 and 66 others)
  must be before 'minecraft:red_mushroom_normal' (defined in 'terralith:orchid_swamp' at index 11, 12 and 214 others)
  must be before 'minecraft:patch_sugar_cane' (defined in 'minecraft:deep_lukewarm_ocean' at index 5, 6 and 173 others)
  must be before 'minecraft:patch_pumpkin' (defined in 'regions_unexplored:orchard' at index 5, 6 and 185 others)
  must be before 'minecraft:trees_badlands' (defined in 'integrateddynamics:meneglin' at index 5, 6)
  must be before 'minecraft:patch_grass_badlands' (defined in 'minecraft:wooded_badlands' at index 1, 2)
...
```

[Crash dump](https://mclo.gs/f0oXcdY)
[Raw crash dump](https://github.com/user-attachments/files/16447270/crash-2024-07-31_21.40.44-client.txt)


Changes made:
- Moved `minecraft:trees_badlands` to immediately follow `minecraft:glow_lichen`.
- Ensured that feature order is as close as possible to vanilla order to avoid cycle issues.

This change ensures that the world generation process completes without errors. Please review the changes and let me know if any further adjustments are needed.

Thanks,
F0x

