### PR TITLE
Fix what_would_i_be_looking_at advancement

### DIFF
--- a/src/main/resources/data/integrateddynamics/advancement/advanced_operations/what_would_i_be_looking_at.json
+++ b/src/main/resources/data/integrateddynamics/advancement/advanced_operations/what_would_i_be_looking_at.json
@@ -18,7 +18,6 @@
       "conditions": {
         "part_type": "integrateddynamics:display_panel",
         "variable": {
-          "type": "value_type",
           "value": {
             "type": "operator",
             "operator": "integrateddynamics:entity_targetblock"


### PR DESCRIPTION
For some reason, the variable had a spurious `"type": "value_type",` which is not present in the 1.20 version of the mod. So, remove this so that the advancement can be unlocked once again.