### PR TITLE
Performance optimizations: Pathfinder ~70x faster, also improved general tick speed

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementTile.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementTile.java
@@ -13,7 +13,7 @@ public class PathElementTile<T extends BlockEntity> extends PathElementCable {
 
     private final T tile;
     private final ICable cable;
-    private DimPos position = null;
+    private final DimPos position;
 
     public PathElementTile(T tile, ICable cable) {
         this.tile = tile;

--- a/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementTile.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementTile.java
@@ -13,10 +13,12 @@ public class PathElementTile<T extends BlockEntity> extends PathElementCable {
 
     private final T tile;
     private final ICable cable;
+    private DimPos position = null;
 
     public PathElementTile(T tile, ICable cable) {
         this.tile = tile;
         this.cable = cable;
+        this.position = DimPos.of(tile.getLevel(), tile.getBlockPos());
     }
 
     protected T getTile() {
@@ -30,7 +32,7 @@ public class PathElementTile<T extends BlockEntity> extends PathElementCable {
 
     @Override
     public DimPos getPosition() {
-        return DimPos.of(tile.getLevel(), tile.getBlockPos());
+        return position;
     }
 
 }

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/ConcurrentWorldIngredientsProxy.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/ConcurrentWorldIngredientsProxy.java
@@ -54,7 +54,7 @@ public class ConcurrentWorldIngredientsProxy<T, M> {
     }
 
     protected Collection<PartPos> getPositions() {
-        return Lists.newArrayList(getNetwork().getPositions());
+        return Sets.newHashSet(getNetwork().getPositions());
     }
 
     public void onWorldTick() {
@@ -107,7 +107,7 @@ public class ConcurrentWorldIngredientsProxy<T, M> {
                 this.states.remove(oldPosition);
                 this.instances.remove(oldPosition);
             }
-            this.oldPositions = Sets.newHashSet(newPositions);
+            this.oldPositions = (Set<PartPos>)newPositions;
         }
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/path/PathFinder.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/path/PathFinder.java
@@ -1,12 +1,15 @@
 package org.cyclops.integrateddynamics.core.path;
 
-import com.google.common.collect.Sets;
 import org.cyclops.cyclopscore.datastructure.DimPos;
 import org.cyclops.integrateddynamics.api.path.IPathElement;
 import org.cyclops.integrateddynamics.api.path.ISidedPathElement;
 
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+
 
 /**
  * Algorithm to construct paths/clusters of {@link IPathElement}s.
@@ -14,35 +17,33 @@ import java.util.TreeSet;
  */
 public final class PathFinder {
 
-    protected static TreeSet<ISidedPathElement> getConnectedElements(ISidedPathElement head, Set<DimPos> visitedPositions) {
-        TreeSet<ISidedPathElement> elements = Sets.newTreeSet();
+    protected static Set<ISidedPathElement> getConnectedElements(ISidedPathElement head) {
+        Set<ISidedPathElement> connectedElements = new HashSet<>();
+        Set<DimPos> visitedPositions = new HashSet<>();
 
-        // Make sure to add our head
-        if(!visitedPositions.contains(head.getPathElement().getPosition())) {
-            elements.add(head);
-            visitedPositions.add(head.getPathElement().getPosition());
-        }
+        // Use a queue for BFS traversal.
+        Queue<ISidedPathElement> queue = new ArrayDeque<>();
+        DimPos headPos = head.getPathElement().getPosition();
+        visitedPositions.add(headPos);
+        queue.offer(head);
 
-        // Add neighbours that haven't been checked yet.
-        for(ISidedPathElement neighbour : head.getPathElement().getReachableElements()) {
-            if(!visitedPositions.contains(neighbour.getPathElement().getPosition())) {
-                elements.add(neighbour);
-                visitedPositions.add(neighbour.getPathElement().getPosition());
+        while (!queue.isEmpty()) {
+            ISidedPathElement current = queue.poll();
+            connectedElements.add(current);
+            IPathElement currentElement = current.getPathElement();
+
+            for (ISidedPathElement neighbour : currentElement.getReachableElements()) {
+                DimPos neighbourPos = neighbour.getPathElement().getPosition();
+                if (visitedPositions.add(neighbourPos)) { // Adds and returns true if not already present.
+                    queue.offer(neighbour);
+                }
             }
         }
 
-        // Loop over the added neighbours to recursively check their neighbours.
-        Set<ISidedPathElement> neighbourElements = Sets.newHashSet();
-        for(ISidedPathElement addedElement : elements) {
-            neighbourElements.addAll(getConnectedElements(addedElement, visitedPositions));
-        }
-        elements.addAll(neighbourElements);
-
-        return elements;
+        return connectedElements;
     }
 
     public static Cluster getConnectedCluster(ISidedPathElement head) {
-        return new Cluster(getConnectedElements(head, Sets.<DimPos>newTreeSet()));
+        return new Cluster(new TreeSet<>(getConnectedElements(head)));
     }
-
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0dfbf425-7ca1-4f39-8d74-de7a9f6ccfc4)

(tick 12-15 ms, destroying one block 7000 ms stall on server)

After:
![image](https://github.com/user-attachments/assets/b41fe431-20fa-4e58-84e8-c1edc6c1eb47)

(tick 4-5 ms, destroying one block 117 ms stall on server)