### PR TITLE
Adds a config to disable the collision for cable

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/GeneralConfig.java
+++ b/src/main/java/org/cyclops/integrateddynamics/GeneralConfig.java
@@ -160,6 +160,10 @@ public class GeneralConfig extends DummyConfig {
     @ConfigurableProperty(category = "machine", comment = "The maximum values that Part Offset items will have when dropped from a broken part.", minimalValue = 1, configLocation = ModConfig.Type.SERVER)
     public static int enchancementOffsetPartDropValue = 4;
 
+    @ConfigurableProperty(category = "machine" , comment = "When true, disable the collision for cable.", configLocation = ModConfig.Type.SERVER)
+    public static boolean disableCableCollision = false;
+
+
     public GeneralConfig() {
         super(IntegratedDynamics._instance, "general");
     }

--- a/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/BlockCable.java
@@ -63,6 +63,7 @@ import org.cyclops.cyclopscore.datastructure.EnumFacingMap;
 import org.cyclops.cyclopscore.helper.BlockEntityHelpers;
 import org.cyclops.cyclopscore.helper.MinecraftHelpers;
 import org.cyclops.cyclopscore.helper.RenderHelpers;
+import org.cyclops.integrateddynamics.GeneralConfig;
 import org.cyclops.integrateddynamics.Reference;
 import org.cyclops.integrateddynamics.RegistryEntries;
 import org.cyclops.integrateddynamics.api.block.IDynamicLight;
@@ -354,7 +355,7 @@ public class BlockCable extends BlockWithEntity implements IDynamicModelElement,
     @SneakyThrows
     @Override
     public VoxelShape getCollisionShape(BlockState blockState, BlockGetter world, BlockPos pos, CollisionContext selectionContext) {
-        if(disableCollisionBox) {
+        if(disableCollisionBox || GeneralConfig.disableCableCollision) {
             return Shapes.empty();
         }
 


### PR DESCRIPTION
In some cases (when there are really a lot of cables in the view), calculating the collision for the cable can be slow. 
So I added a config that allows the player to disable the collision calculation. 

Here is a comparison with about 20000~ cables in a super flat world:
<img width="2560" height="1377" alt="2ca8ef265633ee3cda39e17fbe538665" src="https://github.com/user-attachments/assets/f03469d5-459d-4aa4-afcb-cd43fadef952" />
<img width="2560" height="1377" alt="d1d4ca99fdcea308b3912fd65fbba1bd" src="https://github.com/user-attachments/assets/31464d7c-2675-45e7-8733-553b54096ccf" />
