### PR TITLE
Fix cable shape cache having cache collisions

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/block/shapes/VoxelShapeComponentsFactoryHandlerParts.java
+++ b/src/main/java/org/cyclops/integrateddynamics/block/shapes/VoxelShapeComponentsFactoryHandlerParts.java
@@ -69,7 +69,7 @@ public class VoxelShapeComponentsFactoryHandlerParts implements VoxelShapeCompon
         @Override
         public String getStateId(BlockState blockState, BlockGetter world, BlockPos blockPos) {
             return getPart()
-                    .map(part -> "part(" + part.getPartRenderPosition().toCompactString() + ")")
+                    .map(part -> "part(" + part.getPartRenderPosition().toCompactString() + ";dir=" + this.direction.ordinal() + ")")
                     .orElse("part");
         }
 


### PR DESCRIPTION
When there are two cables with different shapes but identical connections and the same parts (but placed on different sides), cache collision will occur, with both shapes having the same cache key, but different collision shapes. This results in ghost collisions when playing in single player and collision desync between server and the client on dedicated servers.

Example of two cable blocks having different shapes but same cache key, resulting in them having the same shape. Notice how on the second part the collision box on the left should not logically exists, but is shown due to the bug mentioned.

<img width="631" height="432" alt="image" src="https://github.com/user-attachments/assets/732d8ffa-2669-4677-9bd0-38de714e28e1" />
<img width="683" height="470" alt="image" src="https://github.com/user-attachments/assets/21a0d84f-e050-4b6a-ab33-59b03dc0eff9" />
