### PR TITLE
Fix part capabilities not being invalidated when network is reinitialized

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/capability/partcontainer/PartContainerTileMultipartTicking.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/partcontainer/PartContainerTileMultipartTicking.java
@@ -32,6 +32,7 @@ public class PartContainerTileMultipartTicking extends PartContainerDefault {
     @Override
     protected void setChanged() {
         getTile().setChanged();
+        getLevel().invalidateCapabilities(getPos());
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
@@ -387,6 +387,7 @@ public class CableHelpers {
                         .orElseThrow(() -> new IllegalStateException("Could not find a valid path element capability"));
                 INetwork network = networkCarrier.getNetwork();
                 networkCarrier.setNetwork(null);
+                world.invalidateCapabilities(pos);
                 return network.removePathElement(pathElement, null, blockState);
             }
         }

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/Network.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/Network.java
@@ -103,7 +103,7 @@ public class Network implements INetwork {
         this.baseCluster = pathElements;
         gatherCapabilities();
         onConstruct();
-        deriveNetworkElements(baseCluster);
+        deriveNetworkElements(baseCluster, true);
     }
 
     protected void gatherCapabilities() {
@@ -124,7 +124,7 @@ public class Network implements INetwork {
 
     }
 
-    private void deriveNetworkElements(Cluster pathElements) {
+    private void deriveNetworkElements(Cluster pathElements, boolean invalidateCapabilities) {
         if(!killIfEmpty()) {
             for (ISidedPathElement sidedPathElement : pathElements) {
                 Level world = sidedPathElement.getPathElement().getPosition().getLevel(true);
@@ -139,6 +139,9 @@ public class Network implements INetwork {
                     }
                     networkCarrier.setNetwork(null);
                     networkCarrier.setNetwork(this);
+                    if (invalidateCapabilities) {
+                        world.invalidateCapabilities(pos);
+                    }
                 });
                 BlockEntityHelpers.getCapability(world, pos, side, Capabilities.NetworkElementProvider.BLOCK).ifPresent(networkElementProvider -> {
                     for(INetworkElement element : networkElementProvider.createNetworkElements(world, pos)) {
@@ -192,7 +195,7 @@ public class Network implements INetwork {
     public void fromNBTEffective(HolderLookup.Provider provider, CompoundTag tag) {
         this.baseCluster.fromNBT(provider, tag.getCompound("baseCluster"));
         this.crashed = tag.getBoolean("crashed");
-        deriveNetworkElements(baseCluster);
+        deriveNetworkElements(baseCluster, false);
         initialize(true);
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/NetworkElementBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/NetworkElementBase.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import org.cyclops.cyclopscore.datastructure.DimPos;
 import org.cyclops.integrateddynamics.api.network.INetwork;
@@ -96,7 +97,12 @@ public abstract class NetworkElementBase implements INetworkElement {
     }
 
     protected void revalidatePositioned(INetwork network, DimPos dimPos) {
-        NetworkHelpers.getNetworkCarrier(dimPos.getLevel(true), dimPos.getBlockPos(), null)
-                .ifPresent(networkCarrier -> networkCarrier.setNetwork(network));
+        Level level = dimPos.getLevel(true);
+        NetworkHelpers.getNetworkCarrier(level, dimPos.getBlockPos(), null).ifPresent(networkCarrier -> {
+            if (networkCarrier.getNetwork() != network) {
+                networkCarrier.setNetwork(network);
+                level.invalidateCapabilities(dimPos.getBlockPos());
+            }
+        });
     }
 }


### PR DESCRIPTION
This causes capability queries on part blocks to return old capabilities that are no longer valid to access the network