### PR TITLE
TODO: The FLUIDSTACK_3 OperatorBuilder wrongly uses ITEMSTACK.inputTypes instead of FLUIDSTACK.inputTypes

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/OperatorBuilders.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/OperatorBuilders.java
@@ -189,6 +189,7 @@ public class OperatorBuilders {
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> FLUIDSTACK_1_SUFFIX_LONG = FLUIDSTACK.inputTypes(1, ValueTypes.OBJECT_FLUIDSTACK).renderPattern(IConfigRenderPattern.SUFFIX_1_LONG);
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> FLUIDSTACK_2 = FLUIDSTACK.inputTypes(2, ValueTypes.OBJECT_FLUIDSTACK).renderPattern(IConfigRenderPattern.INFIX);
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> FLUIDSTACK_2_LONG = FLUIDSTACK.inputTypes(2, ValueTypes.OBJECT_FLUIDSTACK).renderPattern(IConfigRenderPattern.INFIX_LONG);
+    // TODO: in next major, replace ITEMSTACK with FLUIDSTACK
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> FLUIDSTACK_3 = ITEMSTACK.inputTypes(3, ValueTypes.OBJECT_FLUIDSTACK).renderPattern(IConfigRenderPattern.PREFIX_3_LONG);
     public static final OperatorBuilder<OperatorBase.SafeVariablesGetter> FLUIDSTACK_1_PREFIX_LONG = FLUIDSTACK.inputTypes(1, ValueTypes.OBJECT_FLUIDSTACK).renderPattern(IConfigRenderPattern.PREFIX_1_LONG);
     public static final IterativeFunction.PrePostBuilder<FluidStack, IValue> FUNCTION_FLUIDSTACK = IterativeFunction.PrePostBuilder.begin()


### PR DESCRIPTION
This causes the actual `Item With Data` (operator id: `integrateddynamics:itemstack_withdata`) do be overwritten by the Fluid version, making `Item With Data` completely inaccessible