### PR TITLE
Auto-save part settings and offsets when closing the gui

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartOffset.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartOffset.java
@@ -93,6 +93,14 @@ public class ContainerScreenPartOffset<T extends ContainerPartOffset> extends Co
     }
 
     @Override
+    public void onClose() {
+        // Auto-save the offsets when the gui is closed,
+        // so that players don't have to explicitly confirm their changes.
+        onSave();
+        super.onClose();
+    }
+
+    @Override
     public boolean charTyped(char typedChar, int keyCode) {
         if (!this.numberFieldX.charTyped(typedChar, keyCode)
                 && !this.numberFieldY.charTyped(typedChar, keyCode)

--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartSettings.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartSettings.java
@@ -140,6 +140,14 @@ public class ContainerScreenPartSettings<T extends ContainerPartSettings> extend
         this.refreshValues();
     }
 
+    @Override
+    public void onClose() {
+        // Auto-save the settings when the gui is closed,
+        // so that players don't have to explicitly confirm their changes.
+        onSave();
+        super.onClose();
+    }
+
     protected int getFieldSideY() {
         return 9;
     }


### PR DESCRIPTION
Refs CyclopsMC/IntegratedTunnels#161, and the counterpart of CyclopsMC/IntegratedTunnels#378.

### Problem

The part settings gui (readers, writers, interfaces, …) only pushed its field values to the server when the "Save" button was clicked. Closing the gui with Escape silently discarded everything that had been typed — update interval, priority, channel and target side alike. That is what CyclopsMC/IntegratedTunnels#161 reports for the interface channel, but it applies to every part.

The delay gui and the aspect settings gui already avoid this by saving on input / on close, so this brings the remaining two guis in line.

### Change

`ContainerScreenPartSettings` and `ContainerScreenPartOffset` now override `onClose()` to call `onSave()` before `super.onClose()`. The ordering matters — `onSave()` sends the values through the value notifier, and the server only applies those while `player.containerMenu` is still this menu, so they have to go out before the vanilla container-close packet.

`ContainerScreenPartOffset` already saved on every keystroke/click, so for it this is only a safety net; `ContainerScreenPartSettings` had no auto-save at all.

The save button is deliberately left in place and unchanged in both guis: besides saving, `BUTTON_SAVE` calls `PartHelpers.openContainerPart(...)` server-side, making it the only way back to the part gui. Pressing it is now optional rather than required.

### Testing

* `./gradlew build` passes, including unit tests and `spotlessCheck`.
* Gui code is not covered by automated tests; the save path was verified by reading through the value-notifier flow rather than in-game.