### PR TITLE
Fix crash when displaying piped operators

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/CombinedOperator.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/evaluate/operator/CombinedOperator.java
@@ -23,6 +23,7 @@ import org.cyclops.integrateddynamics.core.evaluate.variable.Variable;
 import org.cyclops.integrateddynamics.core.helper.L10NValues;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -50,8 +51,33 @@ public class CombinedOperator extends OperatorBase {
     }
 
     @Override
-    public IOperator materialize() {
-        return this;
+    public IOperator materialize() throws EvaluationException {
+        // Materialize all combined operators, as these may still refer to non-materialized values.
+        // For example, a curried operator that has a list from an inventory applied to it,
+        // which would otherwise be sent to clients as an unresolvable position-based list proxy. #1703
+        OperatorsFunction function = (OperatorsFunction) getFunction();
+        IOperator[] operators = function.getOperators();
+        IOperator[] materializedOperators = new IOperator[operators.length];
+        boolean changed = false;
+        for (int i = 0; i < operators.length; i++) {
+            materializedOperators[i] = operators[i].materialize();
+            changed |= materializedOperators[i] != operators[i];
+        }
+        return changed ? function.recreate(materializedOperators) : this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CombinedOperator)) return false;
+        CombinedOperator that = (CombinedOperator) o;
+        return Objects.equals(getUniqueName(), that.getUniqueName())
+                && Objects.equals(getFunction(), that.getFunction());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUniqueName(), getFunction());
     }
 
     public static abstract class OperatorsFunction implements IFunction {
@@ -68,6 +94,26 @@ public class CombinedOperator extends OperatorBase {
 
         public int getInputOperatorCount() {
             return getOperators().length;
+        }
+
+        /**
+         * Create a new operator of this same function type for the given operators.
+         * @param operators The operators to combine.
+         * @return The new combined operator.
+         * @throws EvaluationException If the operators can not be combined.
+         */
+        public abstract CombinedOperator recreate(IOperator... operators) throws EvaluationException;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            return Arrays.equals(operators, ((OperatorsFunction) o).operators);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * getClass().hashCode() + Arrays.hashCode(operators);
         }
     }
 
@@ -93,6 +139,11 @@ public class CombinedOperator extends OperatorBase {
         public static CombinedOperator asOperator(IOperator... operators) {
             CombinedOperator.Conjunction conjunction = new CombinedOperator.Conjunction(operators);
             return new CombinedOperator(":&&:", "p_conjunction", "p_conjunction", conjunction, ValueTypes.BOOLEAN);
+        }
+
+        @Override
+        public CombinedOperator recreate(IOperator... operators) {
+            return Conjunction.asOperator(operators);
         }
 
         public static class Serializer extends ListOperatorSerializer<Conjunction> {
@@ -133,6 +184,11 @@ public class CombinedOperator extends OperatorBase {
             return new CombinedOperator(":||:", "p_disjunction", "p_disjunction", disjunction, ValueTypes.BOOLEAN);
         }
 
+        @Override
+        public CombinedOperator recreate(IOperator... operators) {
+            return Disjunction.asOperator(operators);
+        }
+
         public static class Serializer extends ListOperatorSerializer<Disjunction> {
 
             public Serializer() {
@@ -165,6 +221,11 @@ public class CombinedOperator extends OperatorBase {
         public static CombinedOperator asOperator(IOperator operator) {
             CombinedOperator.Negation negation = new CombinedOperator.Negation(operator);
             return new CombinedOperator("!:", "p_negation", "p_negation", negation, ValueTypes.BOOLEAN);
+        }
+
+        @Override
+        public CombinedOperator recreate(IOperator... operators) {
+            return Negation.asOperator(operators[0]);
         }
 
         public static class Serializer extends ListOperatorSerializer<Negation> {
@@ -253,6 +314,11 @@ public class CombinedOperator extends OperatorBase {
             return asOperator(new CombinedOperator.Pipe(operators), ":.:", "piped", "piped", operators);
         }
 
+        @Override
+        public CombinedOperator recreate(IOperator... operators) {
+            return Pipe.asOperator(operators);
+        }
+
         public static CombinedOperator asOperator(OperatorsFunction function, String symbol, String operatorName, String interactName, final IOperator... operators) {
             Pair<IValueType[], IValueType> ioTypes = getPipedInputOutputTypes(operators);
             return new CombinedOperator(symbol, operatorName, interactName, function, ioTypes.getRight()) {
@@ -299,6 +365,11 @@ public class CombinedOperator extends OperatorBase {
 
         public static CombinedOperator asOperator(IOperator... operators) {
             return Pipe.asOperator(new CombinedOperator.Pipe2(operators), ":.2:", "piped2", "piped2", operators);
+        }
+
+        @Override
+        public CombinedOperator recreate(IOperator... operators) {
+            return Pipe2.asOperator(operators);
         }
 
         public static class Serializer extends ListOperatorSerializer<Pipe2> {
@@ -354,6 +425,11 @@ public class CombinedOperator extends OperatorBase {
                 throw new EvaluationException(Component.translatable(e.getMessage()));
             }
             return combinedOperator;
+        }
+
+        @Override
+        public CombinedOperator recreate(IOperator... operators) throws EvaluationException {
+            return Flip.asOperator(operators[0]);
         }
 
         public static class Serializer extends ListOperatorSerializer<Flip> {

--- a/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestOperatorOperators.java
+++ b/src/test/java/org/cyclops/integrateddynamics/core/evaluate/variable/TestOperatorOperators.java
@@ -1,5 +1,7 @@
 package org.cyclops.integrateddynamics.core.evaluate.variable;
 
+import com.google.common.collect.Lists;
+import net.minecraft.resources.ResourceLocation;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
@@ -11,6 +13,8 @@ import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
@@ -825,6 +829,42 @@ public class TestOperatorOperators {
     public void testConditionalOutputTypesPredicatePipe() throws EvaluationException {
         assertThat(Operators.OPERATOR_PIPE.getConditionalOutputType(new IVariable[]{oArithmeticIncrement, oArithmeticIncrement}),
                 CoreMatchers.<IValueType>is(ValueTypes.OPERATOR));
+    }
+
+    @Test
+    public void testMaterializePredicatePipe() throws EvaluationException {
+        // A list that is only resolved when it is iterated over, just like the world-based list proxies.
+        List<ValueTypeInteger.ValueInteger> mutableValues = Lists.newArrayList(i0.getValue(), i1.getValue());
+        DummyVariableList lmutable = new DummyVariableList(ValueTypeList.ValueList.ofFactory(
+                new ValueTypeListProxyBase<ValueTypeInteger, ValueTypeInteger.ValueInteger>(
+                        new ResourceLocation("integrateddynamics", "test_mutable"), ValueTypes.INTEGER) {
+                    @Override
+                    public int getLength() {
+                        return mutableValues.size();
+                    }
+
+                    @Override
+                    public ValueTypeInteger.ValueInteger get(int index) {
+                        return mutableValues.get(index);
+                    }
+                }));
+
+        // contains([0, 1]) . not
+        DummyVariableOperator containsMutable = new DummyVariableOperator((ValueTypeOperator.ValueOperator)
+                Operators.OPERATOR_APPLY.evaluate(new IVariable[]{oListContains, lmutable}));
+        ValueTypeOperator.ValueOperator piped = (ValueTypeOperator.ValueOperator)
+                Operators.OPERATOR_PIPE.evaluate(new IVariable[]{containsMutable, oLogicalNot});
+        DummyVariableOperator materialized = new DummyVariableOperator(ValueTypes.OPERATOR.materialize(piped));
+
+        // Changing the underlying list must not affect the materialized operator anymore
+        mutableValues.clear();
+
+        assertThat("materialized not|contains([0, 1], 1) == false",
+                Operators.OPERATOR_APPLY.evaluate(new IVariable[]{materialized, i1}),
+                equalTo((IValue) ValueTypeBoolean.ValueBoolean.of(false)));
+        assertThat("non-materialized not|contains([], 1) == true",
+                Operators.OPERATOR_APPLY.evaluate(new IVariable[]{new DummyVariableOperator(piped), i1}),
+                equalTo((IValue) ValueTypeBoolean.ValueBoolean.of(true)));
     }
 
     /**


### PR DESCRIPTION
Closes #1703

### Problem

`PartTypePanelVariableDriven.onValueChanged` materializes the display value before it is sent to the client, but `CombinedOperator.materialize()` was `return this;` — it never propagated materialization to the operators it combines.

So for the reporter's `ItemLessThan64 = StoredItemCount . GreaterThen64`, the inner `CurriedOperator` kept the inventory reader's position-based `ValueTypeListProxyPositioned` instead of a materialized list, and that proxy was shipped to the client, where deserializing it blew up:

```
java.util.NoSuchElementException: No value present
	at NBTClassTypesNeoForge$2.readPersistedField          (reading a DimPos)
	at ValueTypeListProxyPositioned.readGeneratedFieldsFromNBT
	at ValueTypeList.deserialize
	at CurriedOperator$Serializer.deserialize
	at CombinedOperator$ListOperatorSerializer.deserialize  <- the pipe
	at ValueTypeOperator.deserialize
	at ValueTypeBase.canDeserialize
	at PartTypePanelVariableDriven$State.deserialize
```

This also explains why displaying the intermediary variables works: a directly-displayed curried operator is fine because `CurriedOperator.materialize()` does materialize its applied values.

### Changes

* `CombinedOperator.materialize()` now materializes each sub-operator and rebuilds the combined operator when anything changed, through a new `OperatorsFunction#recreate(IOperator...)` implemented by `Conjunction`, `Disjunction`, `Negation`, `Pipe`, `Pipe2` and `Flip`. Recursion covers nested pipes.
* Added `equals`/`hashCode` to `CombinedOperator` and `OperatorsFunction`. Without them, materializing yields a fresh instance every tick, so `ValueHelpers.areValuesEqual` in the panel update loop would never match and every display would push a block update every tick.

Besides the crash, the missing recursion also meant the Materializer could not actually materialize piped/flipped operators, leaving world-bound proxies on variable cards.

### Testing

`TestOperatorOperators#testMaterializePredicatePipe` pipes a curried operator that holds a lazily-resolved list, materializes it, then mutates the backing list — the materialized operator must be unaffected. It fails on the old code and passes on the new one. `./gradlew test` is green.

### Note on the branch

The defect is byte-identical on `master-1.20-lts`, `master-1.21-lts`, `master-26-lts` and `master-26`, so this targets `master-1.20-lts` for upmerging.

The reported crash itself only manifests on MC 26, because the exception above is a CyclopsCore regression from the `ValueOutput` migration: in `loader-neoforge/.../NBTClassTypesNeoForge.java` on `master-26-lts` the `DimPos` type writes to a hardcoded child `tag.child("dim")` but reads `tag.child(name).orElseThrow()`, so any persisted `DimPos` fails to read back (`master-1.21-lts` correctly uses `tag.put(name, dimPos)` / `tag.getCompound(name)`). This PR sidesteps it by never sending an unmaterialized positioned proxy, but that CyclopsCore bug still affects everything else persisting a `DimPos` — `PositionedOperator` writes one the same way — and is fixed separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoinY4GW1gaXggj3WxDUcF)_