### PR TITLE
Show modified aspect property values in tooltip

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenMultipartAspects.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenMultipartAspects.java
@@ -8,6 +8,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import org.apache.commons.lang3.tuple.Triple;
@@ -37,6 +38,10 @@ public abstract class ContainerScreenMultipartAspects<P extends IPartType<P, S>,
         extends ContainerScreenScrolling<C> {
 
     private static final Rectangle ITEM_POSITION = new Rectangle(8, 17, 18, 18);
+    /**
+     * The maximum number of characters that are shown for a modified aspect property value in tooltips.
+     */
+    private static final int MAX_PROPERTY_VALUE_LENGTH = 20;
 
     protected final DisplayErrorsComponent displayErrors = new DisplayErrorsComponent();
 
@@ -179,10 +184,21 @@ public abstract class ContainerScreenMultipartAspects<P extends IPartType<P, S>,
                         List<Component> lines = Lists.newLinkedList();
                         lines.add(Component.translatable("gui.integrateddynamics.part.properties")
                                 .withStyle(ChatFormatting.WHITE));
+                        List<MutableComponent> propertyValues = container.getModifiedAspectPropertyValuesSynced(aspect);
+                        int propertyIndex = 0;
                         for(IAspectPropertyTypeInstance property : ((IAspect<?, ?>) aspect).getPropertyTypes()) {
-                            lines.add(Component.literal("-")
+                            MutableComponent line = Component.literal("-")
                                     .withStyle(ChatFormatting.YELLOW)
-                                    .append(Component.translatable(property.getTranslationKey())));
+                                    .append(Component.translatable(property.getTranslationKey()));
+                            MutableComponent value = propertyValues != null && propertyIndex < propertyValues.size()
+                                    ? propertyValues.get(propertyIndex) : null;
+                            if (value != null && !value.getString().isEmpty()) {
+                                line = line
+                                        .append(Component.literal(": ").withStyle(ChatFormatting.YELLOW))
+                                        .append(compactPropertyValue(value));
+                            }
+                            lines.add(line);
+                            propertyIndex++;
                         }
                         drawTooltip(lines, guiGraphics.pose(), mouseX - this.leftPos, mouseY - this.topPos);
                     }
@@ -203,5 +219,18 @@ public abstract class ContainerScreenMultipartAspects<P extends IPartType<P, S>,
 
     public int getMaxLabelWidth() {
         return 63;
+    }
+
+    /**
+     * Create a compact single-line representation of the given aspect property value.
+     * @param value An aspect property value.
+     * @return A compact representation of the given value.
+     */
+    protected static MutableComponent compactPropertyValue(MutableComponent value) {
+        String string = value.getString().replaceAll("\\s+", " ");
+        if (string.length() > MAX_PROPERTY_VALUE_LENGTH) {
+            string = string.substring(0, MAX_PROPERTY_VALUE_LENGTH) + "...";
+        }
+        return Component.literal(string).withStyle(value.getStyle());
     }
 }

--- a/src/main/java/org/cyclops/integrateddynamics/core/inventory/container/ContainerMultipartAspects.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/inventory/container/ContainerMultipartAspects.java
@@ -1,6 +1,9 @@
 package org.cyclops.integrateddynamics.core.inventory.container;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
@@ -10,10 +13,14 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
+import org.cyclops.cyclopscore.helper.ValueNotifierHelpers;
 import org.cyclops.cyclopscore.inventory.SimpleInventory;
 import org.cyclops.cyclopscore.inventory.container.ScrollingInventoryContainer;
 import org.cyclops.cyclopscore.persist.IDirtyMarkListener;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
+import org.cyclops.integrateddynamics.api.PartStateException;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
 import org.cyclops.integrateddynamics.api.item.IAspectVariableFacade;
 import org.cyclops.integrateddynamics.api.item.IVariableFacadeHandlerRegistry;
 import org.cyclops.integrateddynamics.api.part.IPartContainer;
@@ -21,11 +28,15 @@ import org.cyclops.integrateddynamics.api.part.IPartState;
 import org.cyclops.integrateddynamics.api.part.IPartType;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectPropertyTypeInstance;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueHelpers;
 import org.cyclops.integrateddynamics.core.helper.PartHelpers;
 import org.cyclops.integrateddynamics.core.item.AspectVariableFacade;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -50,6 +61,7 @@ public abstract class ContainerMultipartAspects<P extends IPartType<P, S>, S ext
     private final P partType;
     private final Level world;
     private final Map<IAspect, String> aspectPropertyButtons = Maps.newHashMap();
+    private final Map<IAspect, Integer> aspectPropertyValueIds = Maps.newIdentityHashMap();
 
     protected final Container inputSlots;
 
@@ -83,6 +95,7 @@ public abstract class ContainerMultipartAspects<P extends IPartType<P, S>, S ext
             if (aspect.hasProperties()) {
                 String buttonId = "button_aspect_" + aspect.getUniqueName();
                 aspectPropertyButtons.put(aspect, buttonId);
+                aspectPropertyValueIds.put(aspect, getNextValueId());
                 putButtonAction(buttonId, (s, containerExtended) -> {
                     if (!world.isClientSide()) {
                         PartHelpers.openContainerAspectSettings((ServerPlayer) player, target.getCenter(), aspect);
@@ -110,6 +123,71 @@ public abstract class ContainerMultipartAspects<P extends IPartType<P, S>, S ext
 
     public Map<IAspect, String> getAspectPropertyButtons() {
         return Collections.unmodifiableMap(this.aspectPropertyButtons);
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+
+        try {
+            if (!player.level().isClientSide()) {
+                for (Map.Entry<IAspect, Integer> entry : this.aspectPropertyValueIds.entrySet()) {
+                    ValueNotifierHelpers.setValue(this, entry.getValue(), getModifiedAspectPropertyValues(entry.getKey()));
+                }
+            }
+        } catch (PartStateException e) {
+            player.closeContainer();
+        }
+    }
+
+    /**
+     * Determine the values of all properties of the given aspect that deviate from their default value.
+     *
+     * The returned list has one entry for each of the aspect's property types,
+     * in the order of {@link IAspect#getPropertyTypes()}.
+     * Properties that still have their default value are represented by an empty component.
+     *
+     * @param aspect An aspect that has properties.
+     * @return The modified property values, in the order of the aspect's property types.
+     */
+    @SuppressWarnings("unchecked")
+    protected List<MutableComponent> getModifiedAspectPropertyValues(IAspect aspect) {
+        IAspectProperties defaultProperties = aspect.getDefaultProperties();
+        IAspectProperties properties = getPartState().getAspectProperties(aspect);
+        if (properties == null) {
+            properties = defaultProperties;
+        }
+
+        List<MutableComponent> values = Lists.newArrayList();
+        for (IAspectPropertyTypeInstance property : (Collection<IAspectPropertyTypeInstance>) aspect.getPropertyTypes()) {
+            IValue value = properties.getValue(property);
+            IValue defaultValue = defaultProperties.getValue(property);
+            if (value == null || ValueHelpers.areValuesEqual(value, defaultValue)) {
+                values.add(Component.empty());
+            } else {
+                IValueType valueType = value.getType();
+                MutableComponent compactValue = valueType.toCompactString(value);
+                values.add(compactValue == null
+                        ? Component.empty()
+                        : compactValue.withStyle(valueType.getDisplayColorFormat()));
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Get the modified property values of the given aspect, as synced from the server.
+     * @param aspect An aspect.
+     * @return The modified property values, in the order of {@link IAspect#getPropertyTypes()},
+     *         or null if they are unknown.
+     */
+    @Nullable
+    public List<MutableComponent> getModifiedAspectPropertyValuesSynced(IAspect aspect) {
+        Integer valueId = this.aspectPropertyValueIds.get(aspect);
+        if (valueId == null) {
+            return null;
+        }
+        return ValueNotifierHelpers.getValueTextComponentList(this, valueId);
     }
 
     public abstract int getAspectBoxHeight();

--- a/src/main/java/org/cyclops/integrateddynamics/core/inventory/container/ContainerMultipartAspects.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/inventory/container/ContainerMultipartAspects.java
@@ -18,7 +18,6 @@ import org.cyclops.cyclopscore.inventory.SimpleInventory;
 import org.cyclops.cyclopscore.inventory.container.ScrollingInventoryContainer;
 import org.cyclops.cyclopscore.persist.IDirtyMarkListener;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
-import org.cyclops.integrateddynamics.api.PartStateException;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValue;
 import org.cyclops.integrateddynamics.api.evaluate.variable.IValueType;
 import org.cyclops.integrateddynamics.api.item.IAspectVariableFacade;
@@ -36,12 +35,7 @@ import org.cyclops.integrateddynamics.core.item.AspectVariableFacade;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Container for parts.
@@ -129,14 +123,10 @@ public abstract class ContainerMultipartAspects<P extends IPartType<P, S>, S ext
     public void broadcastChanges() {
         super.broadcastChanges();
 
-        try {
-            if (!player.level().isClientSide()) {
-                for (Map.Entry<IAspect, Integer> entry : this.aspectPropertyValueIds.entrySet()) {
-                    ValueNotifierHelpers.setValue(this, entry.getValue(), getModifiedAspectPropertyValues(entry.getKey()));
-                }
+        if (!player.level().isClientSide()) {
+            for (Map.Entry<IAspect, Integer> entry : this.aspectPropertyValueIds.entrySet()) {
+                ValueNotifierHelpers.setValue(this, entry.getValue(), getModifiedAspectPropertyValues(entry.getKey()));
             }
-        } catch (PartStateException e) {
-            player.closeContainer();
         }
     }
 


### PR DESCRIPTION
Closes #1704

The tooltip of the `+` (aspect settings) button in part guis previously only listed the names of an aspect's properties. It now also shows the value of each property that deviates from its default value.

### Changes

**`ContainerMultipartAspects`**
* Allocates one value notifier id per aspect that has properties (in the constructor, so client and server stay in sync).
* On `broadcastChanges`, the server sends a list of components for each such aspect: one entry per property type (in `IAspect#getPropertyTypes()` order), holding the property's compact string representation if it deviates from the aspect's default value, or an empty component otherwise.
* Property values are read via `IPartState#getAspectProperties` (falling back to the aspect defaults when unset), so no part state is mutated as a side effect of rendering the gui.
* Adds `getModifiedAspectPropertyValuesSynced` for the client to read the synced values.

**`ContainerScreenMultipartAspects`**
* Appends `: {value}` to a property's tooltip line when a modified value was synced for it.
* Values are rendered using `IValueType#toCompactString` (so lists already collapse to `[first...]`), styled with the value type's display color, whitespace-collapsed to a single line, and truncated to 20 characters followed by `...` to keep tooltips short.

Since `ContainerExtended#setValue` only sends a packet when the serialized value actually changed, the per-tick recomputation does not add network traffic beyond the initial sync.

### Testing

* `./gradlew build` passes (compilation + unit tests).
* No automated tests were added: this is gui-only rendering behaviour, which `AGENTS.md` explicitly calls out as difficult or impossible to test.