### PR TITLE
Fix writer part aspects not activating during network initialization

### DIFF
--- a/src/integrationtest/java/org/cyclops/integrateddynamics/gametest/GameTestsCombinedAspects.java
+++ b/src/integrationtest/java/org/cyclops/integrateddynamics/gametest/GameTestsCombinedAspects.java
@@ -694,4 +694,29 @@ public class GameTestsCombinedAspects {
         });
     }
 
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testCombinedAspectsWriterActivatesWithoutPlayer(GameTestHelper helper) {
+        // Writers are also activated without a player being involved,
+        // for example when a network is initialized after a world restart,
+        // or when an add-on configures a part programmatically.
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, PartTypes.REDSTONE_WRITER, new ItemStack(PartTypes.REDSTONE_WRITER.getItem()));
+
+        // Place redstone wire next to redstone writer output
+        helper.setBlock(POS.west(), Blocks.REDSTONE_WIRE);
+
+        // Create and place a constant true boolean variable in the writer, without a player
+        PartPos writerPos = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(writerPos, Aspects.Write.Redstone.BOOLEAN,
+                createVariableForValue(helper.getLevel(), ValueTypes.BOOLEAN, ValueTypeBoolean.ValueBoolean.of(true)), null);
+
+        helper.succeedWhen(() -> {
+            IPartStateWriter partStateWriter = (IPartStateWriter) PartHelpers.getPart(writerPos).getState();
+            // Not assertValueEqual, as that throws a NullPointerException when no aspect is active
+            helper.assertTrue(partStateWriter.getActiveAspect() == Aspects.Write.Redstone.BOOLEAN,
+                    "Aspect was not activated without a player, but was " + partStateWriter.getActiveAspect());
+            helper.assertBlockProperty(POS.west(), RedStoneWireBlock.POWER, 15);
+        });
+    }
+
 }

--- a/src/main/java/org/cyclops/integrateddynamics/core/part/write/PartStateWriterBase.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/part/write/PartStateWriterBase.java
@@ -30,6 +30,11 @@ public class PartStateWriterBase<P extends IPartTypeWriter>
         extends PartStateActiveVariableBase<P> implements IPartStateWriter<P> {
 
     private IAspectWrite activeAspect = null;
+    /**
+     * Whether {@link IAspectWrite#onActivate} has been called for {@link #activeAspect}.
+     * This is not persisted, as aspects are always deactivated when their network is killed.
+     */
+    private boolean activeAspectActivated = false;
     private Map<String, List<MutableComponent>> errorMessages = Maps.newHashMap();
     private boolean firstTick = true;
 
@@ -67,6 +72,7 @@ public class PartStateWriterBase<P extends IPartTypeWriter>
     protected void onCorruptedState() {
         super.onCorruptedState();
         this.activeAspect = null;
+        this.activeAspectActivated = false;
     }
 
     @Override
@@ -80,17 +86,25 @@ public class PartStateWriterBase<P extends IPartTypeWriter>
             // We skip network content updates during network init,
             // as it will be called once for all parts right after network init.
             // This is to avoid re-updating variable contents many times during network init, which can get expensive.
-            // We also skip updating activeAspect during network init to avoid clearing it,
-            // as that would break world saves (the activeAspect would be null at save time).
             onVariableContentsUpdated(partType, target);
+        }
 
-            IAspectWrite activeAspect = getActiveAspect();
-            if(activeAspect != null && activeAspect != newAspect) {
-                activeAspect.onDeactivate(partType, target, this);
-            }
-            if(newAspect != null && activeAspect != newAspect) {
-                newAspect.onActivate(partType, target, this);
-            }
+        // Aspects are activated and deactivated at most once,
+        // as networks are killed and revived without the aspect itself changing.
+        IAspectWrite activeAspect = getActiveAspect();
+        if(activeAspect != null && this.activeAspectActivated && activeAspect != newAspect) {
+            activeAspect.onDeactivate(partType, target, this);
+            this.activeAspectActivated = false;
+        }
+        if(newAspect != null && !this.activeAspectActivated) {
+            newAspect.onActivate(partType, target, this);
+            this.activeAspectActivated = true;
+        }
+
+        // Only forget the aspect outside of network (re)initialization.
+        // Otherwise, a part that is saved while its network is being killed
+        // would persist a null aspect, and lose its configuration after a world restart.
+        if(newAspect != null || !isNetworkInitializing) {
             this.activeAspect = newAspect;
         }
     }


### PR DESCRIPTION
Fixes a regression from ba6dd95ebc3239b2072e0dc661d8b2c906dc10f6 (1.34.1) that breaks all Integrated Tunnels parts.

## The regression

That commit moved the aspect (de)activation of `PartStateWriterBase#triggerAspectInfoUpdate` inside the `!isNetworkInitializing` branch:

```java
if (!isNetworkInitializing) {
    onVariableContentsUpdated(partType, target);

    IAspectWrite activeAspect = getActiveAspect();
    ...
    this.activeAspect = newAspect;   // only runs when NOT initializing
}
```

The goal was to stop `beforeNetworkKill` (which passes `newAspect = null, isNetworkInitializing = true`) from clearing the active aspect, as that null would then be persisted, which is what #1628 and #1697 were about.

But the guard also disabled the other half of the lifecycle. `afterNetworkAlive` activates parts through `updateActivation(target, state, null)`, and `isNetworkInitializing` is derived from `player == null`, so it is true there as well. Since 1.34.1, the active aspect is therefore never assigned, and `IAspectWrite#onActivate` is never called, when a network is built. That happens on every world load and on every network rebuild (placing or breaking any cable).

Integrated Dynamics' own writers keep working because their active aspect is restored from NBT, and their aspects don't need `onActivate`. Add-ons do: `onActivate` is what registers their parts with the positioned addons network. All Integrated Tunnels importers, exporters and interfaces stop working as a result.

The reason this was not caught is that the same commit changed the `placeVariableInWriter` game test helper to pass `helper.makeMockPlayer(...)`, which makes `isNetworkInitializing` false. Add-ons configure their parts without a player, so they take the broken path.

## The fix

The two halves are separated again:

* Aspects are activated and deactivated at most once, tracked by a non-persisted `activeAspectActivated` flag. Networks are killed and revived without the aspect itself changing, so this prevents both deactivating an aspect twice and skipping its reactivation.
* The active aspect is only forgotten outside of network initialization, which is what #1628 needed.

`onVariableContentsUpdated` keeps being skipped during network init, as before.

## Verification

Both suites were run against the same build.

| Suite | Before | After |
|---|---|---|
| Integrated Dynamics `runGameTestServer` | 891/891 pass | 892/892 pass |
| Integrated Tunnels `runGameTestServer` | **62 of 146 fail** | **146/146 pass** |

The Integrated Tunnels runs used `master-1.21-lts` published to Maven local, with NeoForge, CyclopsCore and CommonCapabilities held constant, so the ID jar was the only difference. For reference, Integrated Tunnels also passes 146/146 against the released 1.32.0, which is from before the regression.

`testCombinedAspectsWriterPersistsAfterNetworkRebuild`, the regression test that ba6dd95 added for #1628, still passes.

This PR also adds `testCombinedAspectsWriterActivatesWithoutPlayer`, which configures a writer without a player, the path that add-ons and network initialization use. Without the fix it fails with `Aspect was not activated without a player, but was null`.

## Branches

`master-1.20-lts` and `master-1.19-lts` are not affected: ba6dd95 is only contained in `master-1.21-lts`, and both older branches still have the activation outside the `isNetworkInitializing` guard. So this targets `master-1.21-lts` only, and there is nothing to up-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULVbUmc3Uk3ek3d3T4sB9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULVbUmc3Uk3ek3d3T4sB9V)_