### PR TITLE
Return to part gui when pressing escape in part sub-guis

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenAspectSettings.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenAspectSettings.java
@@ -214,9 +214,17 @@ public class ContainerScreenAspectSettings extends ContainerScreenExtended<Conta
                 return false;
             }
         } else {
-            saveSetting();
-            return super.keyPressed(typedChar, keyCode, modifiers);
+            // Don't close all GUIs, but go back to the part's aspect overview GUI.
+            exitToPartGui();
+            return true;
         }
+    }
+
+    /**
+     * Save the current setting and go back to the aspect overview GUI of the part.
+     */
+    protected void exitToPartGui() {
+        buttonExit.onPress();
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartOffset.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartOffset.java
@@ -36,6 +36,7 @@ public class ContainerScreenPartOffset<T extends ContainerPartOffset> extends Co
     private WidgetNumberField numberFieldX = null;
     private WidgetNumberField numberFieldY = null;
     private WidgetNumberField numberFieldZ = null;
+    private ButtonText buttonSave = null;
 
     public ContainerScreenPartOffset(T container, Inventory inventory, Component title) {
         super(container, inventory, title);
@@ -86,7 +87,7 @@ public class ContainerScreenPartOffset<T extends ContainerPartOffset> extends Co
         numberFieldZ.setCanLoseFocus(true);
 
         MutableComponent save = Component.translatable("gui.integrateddynamics.button.save");
-        addRenderableWidget(new ButtonText(this.leftPos + 178, this.topPos + 6, font.width(save.getVisualOrderText()) + 6, 16, save, save,
+        addRenderableWidget(buttonSave = new ButtonText(this.leftPos + 178, this.topPos + 6, font.width(save.getVisualOrderText()) + 6, 16, save, save,
                 createServerPressable(ContainerPartOffset.BUTTON_SAVE, b -> onSave()), true));
 
         this.refreshValues();
@@ -122,8 +123,17 @@ public class ContainerScreenPartOffset<T extends ContainerPartOffset> extends Co
             }
             return true;
         } else {
-            return super.keyPressed(typedChar, keyCode, modifiers);
+            // Don't close all GUIs, but go back to the part's GUI.
+            exitToPartGui();
+            return true;
         }
+    }
+
+    /**
+     * Save the current offsets and go back to the GUI of the part.
+     */
+    protected void exitToPartGui() {
+        buttonSave.onPress();
     }
 
     @Override

--- a/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartSettings.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/client/gui/container/ContainerScreenPartSettings.java
@@ -42,6 +42,7 @@ public class ContainerScreenPartSettings<T extends ContainerPartSettings> extend
     private WidgetNumberField numberFieldChannel = null;
     private WidgetTextFieldDropdown<Direction> dropdownFieldSide = null;
     private List<SideDropdownEntry> dropdownEntries;
+    private ButtonText buttonSave = null;
 
     public ContainerScreenPartSettings(T container, Inventory inventory, Component title) {
         super(container, inventory, title);
@@ -134,7 +135,7 @@ public class ContainerScreenPartSettings<T extends ContainerPartSettings> extend
         }
 
         MutableComponent save = Component.translatable("gui.integrateddynamics.button.save");
-        addRenderableWidget(new ButtonText(this.leftPos + 178, this.topPos + 8, font.width(save.getVisualOrderText()) + 6, 16, save, save,
+        addRenderableWidget(buttonSave = new ButtonText(this.leftPos + 178, this.topPos + 8, font.width(save.getVisualOrderText()) + 6, 16, save, save,
                 createServerPressable(ContainerPartSettings.BUTTON_SAVE, b -> onSave()), true));
 
         this.refreshValues();
@@ -216,8 +217,17 @@ public class ContainerScreenPartSettings<T extends ContainerPartSettings> extend
             }
             return true;
         } else {
-            return super.keyPressed(typedChar, keyCode, modifiers);
+            // Don't close all GUIs, but go back to the part's GUI.
+            exitToPartGui();
+            return true;
         }
+    }
+
+    /**
+     * Save the current settings and go back to the GUI of the part.
+     */
+    protected void exitToPartGui() {
+        buttonSave.onPress();
     }
 
     @Override


### PR DESCRIPTION
Pressing escape in the aspect settings, part settings, or part offsets gui closed *all* guis, forcing the player to re-open the part and navigate back to where they were.

Escape now does the same as the button that already exists in each of these guis for leaving it: it saves the current values and reopens the part gui the player came from.

### Changes

Each of these three screens overrides `keyPressed` and delegated the escape key to `super.keyPressed`, which ends up calling `closeContainer`. Instead, they now trigger the press callback of their existing exit/save button:

| Screen | Button reused | Server action |
| --- | --- | --- |
| `ContainerScreenAspectSettings` | the `<<` button (top-left) | `ContainerAspectSettings.BUTTON_EXIT` |
| `ContainerScreenPartSettings` | the `Save` button | `ContainerPartSettings.BUTTON_SAVE` |
| `ContainerScreenPartOffset` | the `Save` button | `ContainerPartOffset.BUTTON_SAVE` |

All three of those button actions already call `PartHelpers.openContainerPart(...)` server-side, so the part gui reopens instead of everything closing. The client-side half of each callback (`saveSetting()` / `onSave()`) still runs, so escape keeps saving exactly as it did before.

Reusing the buttons' callbacks rather than duplicating their logic keeps the two ways of leaving each gui from drifting apart.

These guis are only ever opened from a part gui (`ContainerMultipart` / `ContainerMultipartAspects`, via `PartHelpers.openContainerPartSettings` / `openContainerPartOffsets` / `openContainerAspectSettings`), so the part gui is always the correct place to return to.

### Testing

`./gradlew compileJava` passes. The change is client-side gui input handling only, so it isn't covered by unit or game tests; verified by reading the existing exit/save button flows it now reuses.