### PR TITLE
Fix cables staying behind in their network when moved by contraption mods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ logs/
 # Ignore files specific to dev environments
 secrets.properties
 changelog.txt
+
+# ClientDevBridge session state (golden images are intentionally kept)
+.clientdevbridge/*
+!.clientdevbridge/golden/

--- a/src/integrationtest/java/org/cyclops/integrateddynamics/gametest/GameTestsNetwork.java
+++ b/src/integrationtest/java/org/cyclops/integrateddynamics/gametest/GameTestsNetwork.java
@@ -10,18 +10,25 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.BlockHitResult;
 import net.neoforged.neoforge.gametest.GameTestHolder;
 import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
 import org.cyclops.cyclopscore.client.particle.ParticleBlurData;
+import org.cyclops.cyclopscore.datastructure.DimPos;
+import org.cyclops.integrateddynamics.IntegratedDynamics;
 import org.cyclops.integrateddynamics.Reference;
 import org.cyclops.integrateddynamics.RegistryEntries;
 import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.path.ISidedPathElement;
+import org.cyclops.integrateddynamics.capability.path.PathElementPosition;
+import org.cyclops.integrateddynamics.capability.path.SidedPathElement;
 import org.cyclops.integrateddynamics.core.helper.CableHelpers;
 import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
 import org.cyclops.integrateddynamics.core.helper.PartHelpers;
 import org.cyclops.integrateddynamics.core.part.PartTypes;
+import org.cyclops.integrateddynamics.core.persist.world.NetworkWorldStorage;
 
 import java.util.Optional;
 
@@ -377,6 +384,39 @@ public class GameTestsNetwork {
             );
 
             helper.assertItemEntityNotPresent(RegistryEntries.ITEM_CABLE.get());
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testNetworkTwoRemovedWithoutBlockEntity(GameTestHelper helper) {
+        // Place two networks directly next to each other
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+        helper.setBlock(POS.offset(1, 0, 0), RegistryEntries.BLOCK_CABLE.value());
+        helper.setBlock(POS.offset(2, 0, 0), RegistryEntries.BLOCK_CABLE.value());
+        helper.setBlock(POS.offset(3, 0, 0), RegistryEntries.BLOCK_CABLE.value());
+
+        // And remove one cable the way contraption mods such as Create do:
+        // the block entity is removed before the block is set to air.
+        BlockPos removedPos = helper.absolutePos(POS.offset(1, 0, 0));
+        helper.getLevel().removeBlockEntity(removedPos);
+        helper.getLevel().setBlock(removedPos, Blocks.AIR.defaultBlockState(),
+                Block.UPDATE_MOVE_BY_PISTON | Block.UPDATE_SUPPRESS_DROPS | Block.UPDATE_KNOWN_SHAPE
+                        | Block.UPDATE_CLIENTS | Block.UPDATE_IMMEDIATE);
+
+        helper.succeedWhen(() -> {
+            INetwork network1 = NetworkHelpers.getNetworkChecked(helper.getLevel(), helper.absolutePos(POS), null);
+            INetwork network3 = NetworkHelpers.getNetworkChecked(helper.getLevel(), helper.absolutePos(POS.offset(2, 0, 0)), null);
+            INetwork network4 = NetworkHelpers.getNetworkChecked(helper.getLevel(), helper.absolutePos(POS.offset(3, 0, 0)), null);
+            helper.assertTrue(network1 != network3, "Networks of disconnected cables are equal");
+            helper.assertTrue(network3 == network4, "Networks of connected cables are not equal");
+
+            // The removed position must not be left behind in any network
+            ISidedPathElement removedPathElement = SidedPathElement
+                    .of(new PathElementPosition(DimPos.of(helper.getLevel(), removedPos)), null);
+            for (INetwork network : NetworkWorldStorage.getInstance(IntegratedDynamics._instance).getNetworks()) {
+                helper.assertFalse(network.containsSidedPathElement(removedPathElement),
+                        "Removed cable is still present in a network");
+            }
         });
     }
 

--- a/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementPosition.java
+++ b/src/main/java/org/cyclops/integrateddynamics/capability/path/PathElementPosition.java
@@ -1,0 +1,26 @@
+package org.cyclops.integrateddynamics.capability.path;
+
+import org.cyclops.cyclopscore.datastructure.DimPos;
+import org.cyclops.integrateddynamics.api.path.IPathElement;
+
+/**
+ * Implementation of {@link IPathElement} that only carries a position.
+ *
+ * Path elements are compared by position only, so this can be used to look up or remove
+ * a path element in a network when the block entity it originated from is not available anymore.
+ *
+ * @author rubensworks
+ */
+public class PathElementPosition extends PathElementDefault {
+
+    private final DimPos position;
+
+    public PathElementPosition(DimPos position) {
+        this.position = position;
+    }
+
+    @Override
+    public DimPos getPosition() {
+        return this.position;
+    }
+}

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/CableHelpers.java
@@ -406,6 +406,12 @@ public class CableHelpers {
                 networkCarrier.setNetwork(null);
                 return network.removePathElement(pathElement, null, blockState);
             }
+
+            // The network can not be reached via the carrier if the block entity was removed
+            // before the block itself was, which is what contraption mods such as Create do
+            // when they pick up a block. Look the position up in the stored networks instead,
+            // as it would otherwise stay behind in its network forever.
+            return NetworkHelpers.removeStalePathElement(world, pos, blockState);
         }
         return true;
     }

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
@@ -314,6 +314,18 @@ public class NetworkHelpers {
     public static boolean removeStalePathElement(Level world, BlockPos pos, BlockState blockState) {
         IPathElement pathElement = new PathElementPosition(DimPos.of(world, pos));
         SidedPathElement sidedPathElement = SidedPathElement.of(pathElement, null);
+
+        // The network we are after is the one the neighbouring cables are still in, so try those first.
+        // Contraption mods move a structure block by block, which makes this by far the common case,
+        // and it keeps us from walking every stored network for each moved block.
+        for (Direction side : Direction.values()) {
+            INetwork network = getNetwork(world, pos.relative(side), side.getOpposite()).orElse(null);
+            if (network != null && network.containsSidedPathElement(sidedPathElement)) {
+                return network.removePathElement(pathElement, null, blockState);
+            }
+        }
+
+        // No neighbour could point us at it, so fall back to looking through all stored networks.
         boolean removed = false;
         for (INetwork network : Lists.newArrayList(NetworkWorldStorage.getInstance(IntegratedDynamics._instance).getNetworks())) {
             if (network.containsSidedPathElement(sidedPathElement)) {

--- a/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/helper/NetworkHelpers.java
@@ -1,5 +1,6 @@
 package org.cyclops.integrateddynamics.core.helper;
 
+import com.google.common.collect.Lists;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -9,6 +10,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.extensions.ILevelExtension;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
+import org.cyclops.cyclopscore.datastructure.DimPos;
 import org.cyclops.cyclopscore.helper.BlockEntityHelpers;
 import org.cyclops.integrateddynamics.Capabilities;
 import org.cyclops.integrateddynamics.GeneralConfig;
@@ -23,6 +25,7 @@ import org.cyclops.integrateddynamics.api.network.IPartNetwork;
 import org.cyclops.integrateddynamics.api.network.IPositionedAddonsNetworkIngredients;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.path.IPathElement;
+import org.cyclops.integrateddynamics.capability.path.PathElementPosition;
 import org.cyclops.integrateddynamics.capability.path.SidedPathElement;
 import org.cyclops.integrateddynamics.core.TickHandler;
 import org.cyclops.integrateddynamics.core.network.Network;
@@ -292,6 +295,32 @@ public class NetworkHelpers {
         for (INetworkElement networkElement : networkElementProvider.createNetworkElements(world, pos)) {
             networkElement.invalidate(network);
         }
+    }
+
+    /**
+     * Remove the path element at the given position from every network that still holds it.
+     *
+     * This is a fallback for when the network can not be reached anymore via the
+     * {@link INetworkCarrier} capability at the position, which happens when the block entity
+     * was removed before the block itself was.
+     * Contraption mods such as Create do this when they pick up a block,
+     * in which case the position would otherwise stay behind in its network forever.
+     *
+     * @param world The world.
+     * @param pos The position.
+     * @param blockState The block state.
+     * @return If the position was removed from at least one network.
+     */
+    public static boolean removeStalePathElement(Level world, BlockPos pos, BlockState blockState) {
+        IPathElement pathElement = new PathElementPosition(DimPos.of(world, pos));
+        SidedPathElement sidedPathElement = SidedPathElement.of(pathElement, null);
+        boolean removed = false;
+        for (INetwork network : Lists.newArrayList(NetworkWorldStorage.getInstance(IntegratedDynamics._instance).getNetworks())) {
+            if (network.containsSidedPathElement(sidedPathElement)) {
+                removed |= network.removePathElement(pathElement, null, blockState);
+            }
+        }
+        return removed;
     }
 
     /**

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/Network.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/Network.java
@@ -450,20 +450,21 @@ public class Network implements INetwork {
             if (level != null) {
                 networkElementProvider = level.getCapability(Capabilities.NetworkElementProvider.BLOCK, position.getBlockPos(), blockState, null, side);
             }
-            if (networkElementProvider != null) {
-                Collection<INetworkElement> networkElements = networkElementProvider.
-                        createNetworkElements(position.getLevel(true), position.getBlockPos());
-                for (INetworkElement networkElement : networkElements) {
-                    if(!removeNetworkElementPre(networkElement)) {
-                        return false;
-                    }
+            // The provider is unavailable if the block entity at the position is already gone.
+            // In that case, fall back to the elements this network derived for the position earlier.
+            Collection<INetworkElement> networkElements = networkElementProvider != null
+                    ? networkElementProvider.createNetworkElements(level, position.getBlockPos())
+                    : getElementsAtPosition(position);
+            for (INetworkElement networkElement : networkElements) {
+                if(!removeNetworkElementPre(networkElement)) {
+                    return false;
                 }
-                for (INetworkElement networkElement : networkElements) {
-                    removeNetworkElementPost(networkElement, blockState);
-                }
-                onNetworkChanged();
-                return true;
             }
+            for (INetworkElement networkElement : networkElements) {
+                removeNetworkElementPost(networkElement, blockState);
+            }
+            onNetworkChanged();
+            return true;
         } else {
             Thread.dumpStack();
             IntegratedDynamics.clog(org.apache.logging.log4j.Level.WARN, "Tried to remove a path element from a network it was not present in.");
@@ -471,6 +472,21 @@ public class Network implements INetwork {
             System.out.println("Tried removing element: " + pathElement);
         }
         return false;
+    }
+
+    /**
+     * @param position A position.
+     * @return The elements of this network that live at the given position.
+     */
+    protected Collection<INetworkElement> getElementsAtPosition(DimPos position) {
+        List<INetworkElement> elementsAtPosition = Lists.newArrayList();
+        for (INetworkElement element : this.elements) {
+            if (element instanceof IPositionedNetworkElement positionedElement
+                    && position.equals(positionedElement.getPosition())) {
+                elementsAtPosition.add(element);
+            }
+        }
+        return elementsAtPosition;
     }
 
     @Override


### PR DESCRIPTION
Refs #1716

## The bug

Contraption mods built on Create remove the block entity *before* setting the block to air when they pick up a block. `Contraption#removeBlocksFromWorld` does:

```java
world.removeBlockEntity(add);
int flags = Block.UPDATE_MOVE_BY_PISTON | Block.UPDATE_SUPPRESS_DROPS | Block.UPDATE_KNOWN_SHAPE
    | Block.UPDATE_CLIENTS | Block.UPDATE_IMMEDIATE;
world.setBlock(add, Blocks.AIR.defaultBlockState(), flags);
```

By the time `BlockCable#onRemove` runs, the network can not be reached through the position's `INetworkCarrier` capability anymore (the carrier is either gone, or is the removed block entity's carrier with a `null` network). `CableHelpers#onCableRemoving` hits neither branch and silently does nothing, so the position stays behind in its network forever.

`onCableRemoved` then builds a correct new network for the surviving cables, so **every contraption assembly leaks one network** that is persisted and ticked. On the next world load this surfaces as exactly the warnings from #1716:

```
Skipped loading part from a network at position BlockPos{...} because it has no valid path element.
Detected network position at position BlockPos{...} with corrupted network, recreating network...
```

## Reproduction

Verified in a dev client with Create 6.0.10 and IntegratedDynamics-Compat, driven with clientdevbridge-cli: a mechanical bearing under a row of three cables, toggled with a creative motor.

Before:

```
before:    net#242117713  cables=3 [0/6/3(cable), 1/6/3(cable), 2/6/3(cable)]
assembled: net#1026384218 cables=2 [1/6/3(cable), 2/6/3(cable)]
        || net#242117713  cables=1 [0/6/3(AIR)]        <- orphan
disasm:    net#1649932268 cables=3 [0/6/3, 1/6/3, 2/6/3]
        || net#242117713  cables=1 [0/6/3]             <- same position in two networks
+5 toggles: 4 orphaned networks, all claiming the same dead position
```

After:

```
before:    net#1696949471 cables=3 [0/6/3, 1/6/3, 2/6/3]
assembled: net#1909876647 cables=2 [1/6/3, 2/6/3]
disasm:    net#1099762612 cables=3 [0/6/3, 1/6/3, 2/6/3]
+6 toggles: still exactly one network
```

Reloading the world after the "before" run logs the `Skipped loading part from a network` warnings; after the fix it logs none.

## The change

- `CableHelpers#onCableRemoving` falls back to a position-based lookup when the network can not be reached through the carrier.
- `NetworkHelpers#removeStalePathElement` finds every stored network that still holds the position and removes it. Path elements are compared by position only, so the new `PathElementPosition` is enough to look one up without a block entity.
- `Network#removePathElement` falls back to the network elements it derived for the position earlier when the `INetworkElementProvider` capability is gone as well, so those are cleaned up instead of leaking. Previously it removed the path element from the cluster but skipped element removal and `onNetworkChanged()`, and returned `false`.

## Testing

`testNetworkTwoRemovedWithoutBlockEntity` in `GameTestsNetwork` removes a cable the way contraption mods do and asserts the position is not left behind in any network. It fails on `master-1.21-lts` (`Removed cable is still present in a network`) and passes with the fix.

`./gradlew build` and `./gradlew runGameTestServer` (all 942 tests) pass.

## Not covered by this change

The server stall in the log files attached to #1716 is a separate problem and is not fixed here. All three watchdog thread dumps show the same stack, with no Integrated Dynamics frames in it:

```
ServerChunkCache.getChunk <- Level.getChunk <- lithium ChunkAwareBlockCollisionSweeper
<- Shapes.collide <- Entity.collide <- sable$collideRedirect <- Entity.move <- ItemEntity.tick
```

Right before that tick, Sable logs `Enormous local sub-level collision bounds, quitting.` ~45 times. That guard trips on the entity's own swept AABB in world space, so the item entity already had a huge delta movement before Sable transformed anything; the vanilla collision sweep then walks chunk sections at sub-level coordinates around x=20,481,000 and generates ungenerated chunks synchronously. That belongs to the physics/collision side rather than to this mod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWtMBWaxBPR99VhV5nhkF7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWtMBWaxBPR99VhV5nhkF7)_