### PR TITLE
Add ingredient index benchmarks for collision-heavy and plain storage shapes

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
+++ b/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
@@ -9,6 +9,9 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ItemContainerContents;
+import net.minecraft.world.item.component.ItemLore;
 import org.apache.logging.log4j.Level;
 import org.cyclops.commoncapabilities.api.capability.itemhandler.ItemMatch;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
@@ -24,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
 
@@ -110,6 +114,64 @@ public class GameTestsPerformanceIngredientIndex {
         });
     }
 
+    // The benchmarks below repeat the two hottest operations over collision-heavy shapes.
+    // They are the cases that a component-blind ItemStack hash makes quadratic.
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupExactSingleItem(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_exact", OPERATIONS, Shape.SINGLE_ITEM, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), IngredientComponent.ITEMSTACK.getMatcher()
+                        .getExactMatchNoQuantityCondition()));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexModificationSingleItem(GameTestHelper helper) {
+        benchmark(helper, "index_modification", OPERATIONS, Shape.SINGLE_ITEM, fixture -> i -> {
+            ItemStack instance = fixture.instance(i);
+            PrioritizedPartPos pos = fixture.positionOf(i);
+            fixture.getIndex().removePosition(instance, pos);
+            fixture.getIndex().addPosition(instance, pos);
+            return 1;
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupExactFewItems(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_exact", OPERATIONS, Shape.FEW_ITEMS, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), IngredientComponent.ITEMSTACK.getMatcher()
+                        .getExactMatchNoQuantityCondition()));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexModificationFewItems(GameTestHelper helper) {
+        benchmark(helper, "index_modification", OPERATIONS, Shape.FEW_ITEMS, fixture -> i -> {
+            ItemStack instance = fixture.instance(i);
+            PrioritizedPartPos pos = fixture.positionOf(i);
+            fixture.getIndex().removePosition(instance, pos);
+            fixture.getIndex().addPosition(instance, pos);
+            return 1;
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupExactHeavyComponents(GameTestHelper helper) {
+        // Guards the opposite risk: a hash that includes components costs more per call
+        benchmark(helper, "index_lookup_exact", OPERATIONS, Shape.HEAVY_COMPONENTS, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), IngredientComponent.ITEMSTACK.getMatcher()
+                        .getExactMatchNoQuantityCondition()));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexModificationHeavyComponents(GameTestHelper helper) {
+        benchmark(helper, "index_modification", OPERATIONS, Shape.HEAVY_COMPONENTS, fixture -> i -> {
+            ItemStack instance = fixture.instance(i);
+            PrioritizedPartPos pos = fixture.positionOf(i);
+            fixture.getIndex().removePosition(instance, pos);
+            fixture.getIndex().addPosition(instance, pos);
+            return 1;
+        });
+    }
+
     protected static int count(Iterator<?> iterator) {
         int count = 0;
         while (iterator.hasNext()) {
@@ -130,6 +192,12 @@ public class GameTestsPerformanceIngredientIndex {
      */
     protected static void benchmark(GameTestHelper helper, String name, int operations,
                                     Function<Fixture, IntUnaryOperator> operationFactory) {
+        benchmark(helper, name, operations, Shape.SPREAD, operationFactory);
+    }
+
+    protected static void benchmark(GameTestHelper helper, String name, int operations, Shape shape,
+                                    Function<Fixture, IntUnaryOperator> operationFactory) {
+        name = name + shape.benchmarkSuffix();
         if (!GameTestsPerformance.isBenchmarkingEnabled()) {
             IntegratedDynamics.clog(Level.INFO, "Performance benchmarking disabled (PERFORMANCE_BENCHMARK_ENABLED not set)");
             helper.succeed();
@@ -140,7 +208,7 @@ public class GameTestsPerformanceIngredientIndex {
 
         double[] operationTimes = new double[ROUNDS];
         for (int round = 0; round < ROUNDS; round++) {
-            IntUnaryOperator operation = operationFactory.apply(new Fixture(helper));
+            IntUnaryOperator operation = operationFactory.apply(new Fixture(helper, shape));
 
             // Accumulate all operation results, so that they can not be optimized away
             long checksum = 0;
@@ -173,6 +241,43 @@ public class GameTestsPerformanceIngredientIndex {
     }
 
     /**
+     * How the indexed instances are spread over item types.
+     *
+     * An ItemStack hash that ignores data components puts every stack of the same item in one
+     * bucket, so the shape decides how long the collision chains are. SPREAD is the mildest case
+     * and SINGLE_ITEM the worst.
+     */
+    public enum Shape {
+        /**
+         * Spread over every registered item, with component variants to reach the target size.
+         */
+        SPREAD,
+        /**
+         * Every instance on one item, distinct only by data components.
+         * This is what a storage full of enchanted books or damaged tools looks like.
+         */
+        SINGLE_ITEM,
+        /**
+         * Spread over a few item types only, distinct by data components within each.
+         */
+        FEW_ITEMS,
+        /**
+         * Spread as SPREAD, but each stack carries a large component payload,
+         * so that the cost of hashing the components themselves is visible.
+         */
+        HEAVY_COMPONENTS;
+
+        public String benchmarkSuffix() {
+            return this == SPREAD ? "" : "_" + name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /**
+     * The number of distinct item types used by {@link Shape#FEW_ITEMS}.
+     */
+    public static final int FEW_ITEMS_COUNT = 50;
+
+    /**
      * An index that is filled with a large number of instances, spread over a large number of positions.
      */
     protected static class Fixture {
@@ -182,6 +287,10 @@ public class GameTestsPerformanceIngredientIndex {
         private final List<PrioritizedPartPos> positions;
 
         public Fixture(GameTestHelper helper) {
+            this(helper, Shape.SPREAD);
+        }
+
+        public Fixture(GameTestHelper helper, Shape shape) {
             this.index = new IngredientPositionsIndex<>(IngredientComponent.ITEMSTACK);
             this.instances = new ArrayList<>(INSTANCES);
             this.positions = new ArrayList<>(POSITIONS);
@@ -192,16 +301,51 @@ public class GameTestsPerformanceIngredientIndex {
                 this.positions.add(PrioritizedPartPos.of(partPos, i % 4));
             }
 
-            // Create instances based on all registered items,
-            // with additional data component variants to reach the target size.
-            List<Item> items = BuiltInRegistries.ITEM.stream().toList();
+            // Air has to be excluded: a stack of it is empty, and an empty stack carries no
+            // components, so a fixture built on it would index nothing.
+            List<Item> items = BuiltInRegistries.ITEM.stream()
+                    .filter(item -> item != Items.AIR)
+                    .toList();
             for (int i = 0; i < INSTANCES; i++) {
-                ItemStack instance = new ItemStack(items.get(i % items.size()));
-                if (i >= items.size()) {
-                    instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + (i / items.size())));
-                }
+                ItemStack instance = createInstance(shape, items, i);
                 this.instances.add(instance);
                 this.index.addPosition(instance, positionOf(i));
+            }
+        }
+
+        private static ItemStack createInstance(Shape shape, List<Item> items, int i) {
+            switch (shape) {
+                case SINGLE_ITEM -> {
+                    ItemStack instance = new ItemStack(items.get(0));
+                    instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + i));
+                    return instance;
+                }
+                case FEW_ITEMS -> {
+                    ItemStack instance = new ItemStack(items.get(i % FEW_ITEMS_COUNT));
+                    instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + (i / FEW_ITEMS_COUNT)));
+                    return instance;
+                }
+                case HEAVY_COMPONENTS -> {
+                    ItemStack instance = new ItemStack(items.get(i % items.size()));
+                    instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + (i / items.size())));
+                    instance.set(DataComponents.LORE, new ItemLore(List.of(
+                            Component.literal("Payload line one for entry " + i),
+                            Component.literal("Payload line two for entry " + i),
+                            Component.literal("Payload line three for entry " + i))));
+                    List<ItemStack> contained = new ArrayList<>(4);
+                    for (int c = 0; c < 4; c++) {
+                        contained.add(new ItemStack(items.get((i + c) % items.size()), 1 + c));
+                    }
+                    instance.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(contained));
+                    return instance;
+                }
+                default -> {
+                    ItemStack instance = new ItemStack(items.get(i % items.size()));
+                    if (i >= items.size()) {
+                        instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + (i / items.size())));
+                    }
+                    return instance;
+                }
             }
         }
 

--- a/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
+++ b/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
@@ -197,6 +197,30 @@ public class GameTestsPerformanceIngredientIndex {
     }
 
     @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupExactMixed(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_exact", OPERATIONS, Shape.MIXED, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), IngredientComponent.ITEMSTACK.getMatcher()
+                        .getExactMatchNoQuantityCondition()));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupItemMixed(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_item", OPERATIONS, Shape.MIXED, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), ItemMatch.ITEM));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexModificationMixed(GameTestHelper helper) {
+        benchmark(helper, "index_modification", OPERATIONS, Shape.MIXED, fixture -> i -> {
+            ItemStack instance = fixture.instance(i);
+            PrioritizedPartPos pos = fixture.positionOf(i);
+            fixture.getIndex().removePosition(instance, pos);
+            fixture.getIndex().addPosition(instance, pos);
+            return 1;
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
     public void testPerformanceIndexLookupItemSingleItem(GameTestHelper helper) {
         benchmark(helper, "index_lookup_item", OPERATIONS, Shape.SINGLE_ITEM, fixture ->
                 i -> fixture.countPositions(fixture.instance(i), ItemMatch.ITEM));
@@ -301,7 +325,13 @@ public class GameTestsPerformanceIngredientIndex {
          * item and its count. This is what a large modpack's storage mostly looks like: many unique
          * items, few component variants.
          */
-        PLAIN;
+        PLAIN,
+        /**
+         * {@link #MIXED_COMPONENT_FRACTION} of the instances carry a component, the rest are plain.
+         * A more realistic modpack storage than either PLAIN or SPREAD: bulk material dominates,
+         * with a tail of enchanted, damaged or named items.
+         */
+        MIXED;
 
         public String benchmarkSuffix() {
             return this == SPREAD ? "" : "_" + name().toLowerCase(Locale.ROOT);
@@ -312,6 +342,11 @@ public class GameTestsPerformanceIngredientIndex {
      * The number of distinct item types used by {@link Shape#FEW_ITEMS}.
      */
     public static final int FEW_ITEMS_COUNT = 50;
+
+    /**
+     * One in this many instances carries a component under {@link Shape#MIXED}.
+     */
+    public static final int MIXED_COMPONENT_FRACTION = 10;
 
     /**
      * An index that is filled with a large number of instances, spread over a large number of positions.
@@ -378,6 +413,13 @@ public class GameTestsPerformanceIngredientIndex {
                 case PLAIN -> {
                     // Distinct by item and count only, so that no stack carries a component patch
                     return new ItemStack(items.get(i % items.size()), 1 + i / items.size());
+                }
+                case MIXED -> {
+                    ItemStack instance = new ItemStack(items.get(i % items.size()), 1 + i / items.size());
+                    if (i % MIXED_COMPONENT_FRACTION == 0) {
+                        instance.set(DataComponents.CUSTOM_NAME, Component.literal("Variant " + i));
+                    }
+                    return instance;
                 }
                 default -> {
                     ItemStack instance = new ItemStack(items.get(i % items.size()));

--- a/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
+++ b/src/main/java/org/cyclops/integrateddynamics/gametest/GameTestsPerformanceIngredientIndex.java
@@ -172,6 +172,36 @@ public class GameTestsPerformanceIngredientIndex {
         });
     }
 
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupExactPlain(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_exact", OPERATIONS, Shape.PLAIN, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), IngredientComponent.ITEMSTACK.getMatcher()
+                        .getExactMatchNoQuantityCondition()));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupItemPlain(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_item", OPERATIONS, Shape.PLAIN, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), ItemMatch.ITEM));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexModificationPlain(GameTestHelper helper) {
+        benchmark(helper, "index_modification", OPERATIONS, Shape.PLAIN, fixture -> i -> {
+            ItemStack instance = fixture.instance(i);
+            PrioritizedPartPos pos = fixture.positionOf(i);
+            fixture.getIndex().removePosition(instance, pos);
+            fixture.getIndex().addPosition(instance, pos);
+            return 1;
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 6000, environment = Reference.MOD_ID + ":performance_index")
+    public void testPerformanceIndexLookupItemSingleItem(GameTestHelper helper) {
+        benchmark(helper, "index_lookup_item", OPERATIONS, Shape.SINGLE_ITEM, fixture ->
+                i -> fixture.countPositions(fixture.instance(i), ItemMatch.ITEM));
+    }
+
     protected static int count(Iterator<?> iterator) {
         int count = 0;
         while (iterator.hasNext()) {
@@ -265,7 +295,13 @@ public class GameTestsPerformanceIngredientIndex {
          * Spread as SPREAD, but each stack carries a large component payload,
          * so that the cost of hashing the components themselves is visible.
          */
-        HEAVY_COMPONENTS;
+        HEAVY_COMPONENTS,
+        /**
+         * Every instance is a plain stack carrying no data components at all, made distinct by its
+         * item and its count. This is what a large modpack's storage mostly looks like: many unique
+         * items, few component variants.
+         */
+        PLAIN;
 
         public String benchmarkSuffix() {
             return this == SPREAD ? "" : "_" + name().toLowerCase(Locale.ROOT);
@@ -338,6 +374,10 @@ public class GameTestsPerformanceIngredientIndex {
                     }
                     instance.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(contained));
                     return instance;
+                }
+                case PLAIN -> {
+                    // Distinct by item and count only, so that no stack carries a component patch
+                    return new ItemStack(items.get(i % items.size()), 1 + i / items.size());
                 }
                 default -> {
                     ItemStack instance = new ItemStack(items.get(i % items.size()));


### PR DESCRIPTION
The existing `GameTestsPerformanceIngredientIndex` benchmarks build their fixture by spreading instances over every registered item, adding component variants only once the item list is exhausted. One shape, and a middling one: collision chains stay short enough to hide the shapes that hurt, and it carries enough components to hide the shape that dominates real storages.

Four shapes are added:

* `SINGLE_ITEM`: every instance on one item, distinct only by components. A storage full of enchanted books, damaged tools, or written books.
* `FEW_ITEMS`: spread over 50 item types with component variants within each.
* `HEAVY_COMPONENTS`: spread as before, but every stack carries lore and container contents, so the cost of hashing a component map is visible. This guards the opposite risk, a hash that is more discriminating but more expensive.
* `PLAIN`: instances distinct by item and count only, so none carries a component patch. This is what a large modpack storage mostly looks like, many unique items and few component variants, and no benchmark covered it.
* `MIXED`: one instance in ten carries a component and the rest are plain. `PLAIN` and `SPREAD` bracket a real storage network rather than describing one; this sits between them.

Item-only lookups also only had a benchmark on the spread shape, although the number of variants of one item is exactly what decides their cost. They are now covered on the plain and single-item shapes too.

Eighteen benchmarks in total. The existing `SPREAD` shape and its benchmark names are unchanged, so existing result history stays comparable.

This is measurement only. It does not depend on any CyclopsCore change and can be merged on its own.

## One correction to the existing fixture

`BuiltInRegistries.ITEM.stream()` includes `minecraft:air`. A stack of air is empty, and an empty stack carries no components, so any fixture entry built on it indexes nothing. That was harmless while air came up once per pass over the registry, but it makes a single-item shape index nothing at all. Air is now filtered out of the pool.

## Numbers

`PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew runGameTestServer`, ms per operation, medians of six runs, against CyclopsCore 1.30.4-DEV as it is on `master-26-lts` today.

| benchmark | ms/op |
|---|---:|
| index_lookup_exact | 0.004670 |
| index_lookup_item | 0.268168 |
| index_lookup_nonempty_first | 0.000243 |
| index_lookup_nonempty_all | 0.012368 |
| index_modification | 0.000744 |
| index_lookup_exact_plain | 0.001227 |
| index_lookup_item_plain | 0.231160 |
| index_modification_plain | 0.000540 |
| index_lookup_exact_mixed | 0.001618 |
| index_lookup_item_mixed | 0.220683 |
| index_modification_mixed | 0.000501 |
| index_lookup_exact_single_item | 3.796415 |
| index_modification_single_item | 3.291132 |
| index_lookup_item_single_item | 0.432068 |
| index_lookup_exact_few_items | 0.070593 |
| index_modification_few_items | 0.156185 |
| index_lookup_exact_heavy_components | 0.003482 |
| index_modification_heavy_components | 0.000423 |

Two things stand out, and both were invisible before.

The single-item shape is roughly 800 times slower per operation than the spread shape, because a component-blind ItemStack hash puts every variant of one item in a single bucket.

Item-only lookups cost 0.22 to 0.27 ms per operation on every shape, which is 200 to 500 times the cost of an exact lookup. That is not hashing at all: `IngredientMapSingleClassified` falls through to a full scan whenever the queried classifier holds nothing, which for a per-priority index is most lookups.

CyclopsMC/CyclopsCore#238 addresses both. With it these become 0.001252 and 0.001053 respectively.

`./gradlew build` passes.