### PR TITLE
Let insert pre-consumers see what part of an insertion is still unclaimed (1.20)

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/api/network/INetworkIngredientsChannel.java
+++ b/src/main/java/org/cyclops/integrateddynamics/api/network/INetworkIngredientsChannel.java
@@ -10,6 +10,21 @@ import javax.annotation.Nonnull;
  */
 public interface INetworkIngredientsChannel<T, M> extends IIngredientComponentStorage<T, M> {
 
+    /**
+     * Insert an ingredient of which a part was already claimed before it reached this channel.
+     *
+     * This is needed when an ingredient is first offered to an insert pre-consumer outside of this channel,
+     * so that the pre-consumers of this channel can not claim that same part a second time.
+     *
+     * @param ingredient The ingredient to insert.
+     * @param unclaimed The part of the ingredient that no insert pre-consumer has claimed yet.
+     * @param simulate If the insertion should be simulated.
+     * @return The ingredient that could not be inserted.
+     */
+    public default T insert(@Nonnull T ingredient, @Nonnull T unclaimed, boolean simulate) {
+        return insert(ingredient, simulate);
+    }
+
     public Iterable<PartPos> findNonFullPositions();
     public Iterable<PartPos> findAllPositions();
     public Iterable<PartPos> findNonEmptyPositions();

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/IIngredientChannelInsertPreConsumer.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/IIngredientChannelInsertPreConsumer.java
@@ -1,6 +1,9 @@
 package org.cyclops.integrateddynamics.core.network;
 
+import org.cyclops.commoncapabilities.api.ingredient.IIngredientMatcher;
+
 import javax.annotation.Nonnull;
+import java.util.Collection;
 
 /**
  * Allows (partially) consuming an ingredient before it is inserted into the network.
@@ -15,7 +18,91 @@ public interface IIngredientChannelInsertPreConsumer<T> {
      * @param ingredient The ingredient instance.
      * @param simulate Simulation mode or not.
      * @return The remaining ingredient instance.
+     * @deprecated Implement {@link #insert(int, Object, Object, boolean)} instead,
+     *             which also tracks the part of the insertion that is still unclaimed.
      */
-    public T insert(int channel, @Nonnull T ingredient, boolean simulate);
+    @Deprecated // TODO: rm in next major
+    public default T insert(int channel, @Nonnull T ingredient, boolean simulate) {
+        return ingredient;
+    }
+
+    /**
+     * Called before an ingredient is inserted into the network.
+     *
+     * All pre-consumers of a network observe the same insertion, one after the other,
+     * each one receiving what the previous one left.
+     * A pre-consumer can do two independent things with it, see {@link Result}:
+     * it can take part of it away, and it can claim part of it.
+     * Only the unclaimed part may be claimed,
+     * so that one insertion is never claimed by multiple pre-consumers.
+     *
+     * @param channel The network channel.
+     * @param ingredient The part of the insertion that still has to be inserted into the network.
+     * @param unclaimed The part of the insertion that no pre-consumer has claimed yet.
+     *                  This is never larger than the given ingredient.
+     * @param simulate Simulation mode or not.
+     * @return What is left to insert into the network, and what of it is left unclaimed.
+     */
+    public default Result<T> insert(int channel, @Nonnull T ingredient, @Nonnull T unclaimed, boolean simulate) {
+        return new Result<>(insert(channel, ingredient, simulate), unclaimed);
+    }
+
+    /**
+     * Run the given ingredient instance through all the given pre-consumers.
+     * @param preConsumers The pre-consumers of the network channel.
+     * @param matcher The matcher of the ingredient component.
+     * @param channel The network channel.
+     * @param ingredient The ingredient instance that is being inserted.
+     * @param unclaimed The part of the insertion that no pre-consumer has claimed yet,
+     *                  which is the whole instance unless a pre-consumer was already applied to it.
+     * @param simulate Simulation mode or not.
+     * @return The remaining ingredient instance that still has to be inserted into the network.
+     */
+    public static <T, M> T applyAll(Collection<IIngredientChannelInsertPreConsumer<T>> preConsumers,
+                                    IIngredientMatcher<T, M> matcher, int channel, @Nonnull T ingredient,
+                                    @Nonnull T unclaimed, boolean simulate) {
+        for (IIngredientChannelInsertPreConsumer<T> preConsumer : preConsumers) {
+            Result<T> result = preConsumer.insert(channel, ingredient, unclaimed, simulate);
+            ingredient = result.remaining();
+            unclaimed = result.unclaimed();
+
+            // Pre-consumers on the deprecated api take away without claiming, so restore the invariant
+            long remainingQuantity = matcher.getQuantity(ingredient);
+            if (matcher.getQuantity(unclaimed) > remainingQuantity) {
+                unclaimed = matcher.withQuantity(unclaimed, remainingQuantity);
+            }
+        }
+        return ingredient;
+    }
+
+    /**
+     * The outcome of a pre-consumer insertion.
+     *
+     * These two are tracked separately because a pre-consumer can do two independent things
+     * with the insertion it observes:
+     *
+     * It can <i>take part of it away</i>, so that that part is no longer inserted into the network.
+     * A crafting interface does this with the produced ingredients that a dependent crafting job
+     * still needs as an input, which it moves into that job's buffer.
+     *
+     * It can also <i>claim part of it</i>, without taking it away:
+     * it recognizes that part as the ingredient it was waiting for, but the ingredient itself
+     * still has to reach the network storage. A crafting interface does this with the outputs of
+     * its own crafting jobs: seeing the output is what completes the job, but the output is
+     * exactly what the network asked for, so it must still be stored.
+     *
+     * Taking away reduces both, claiming only reduces the unclaimed part.
+     * Claiming has to be tracked separately for this reason:
+     * an insertion that is only claimed is passed on to the next pre-consumer unchanged,
+     * so without it, every pre-consumer would claim that same insertion for itself.
+     *
+     * @param remaining What still has to be inserted into the network.
+     *                  Only what a pre-consumer took away is missing from this.
+     * @param unclaimed What no pre-consumer has claimed yet, and a next one may still claim.
+     *                  Both what was taken away and what was only claimed is missing from this,
+     *                  so this is never larger than the remaining part.
+     */
+    public static record Result<T>(T remaining, T unclaimed) {
+    }
 
 }

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientChannelAdapter.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientChannelAdapter.java
@@ -131,12 +131,16 @@ public abstract class IngredientChannelAdapter<T, M> implements INetworkIngredie
 
     @Override
     public T insert(@Nonnull T ingredient, boolean simulate) {
-        // First run the ingredient instance through the pre-consumers.
-        for (IIngredientChannelInsertPreConsumer<T> insertPreConsumer : network.getInsertPreConsumers()) {
-            ingredient = insertPreConsumer.insert(this.channel, ingredient, simulate);
-        }
+        return insert(ingredient, ingredient, simulate);
+    }
 
+    @Override
+    public T insert(@Nonnull T ingredient, @Nonnull T unclaimed, boolean simulate) {
         IIngredientMatcher<T, M> matcher = getComponent().getMatcher();
+
+        // First run the ingredient instance through the pre-consumers.
+        ingredient = IIngredientChannelInsertPreConsumer.applyAll(network.getInsertPreConsumers(), matcher,
+                this.channel, ingredient, unclaimed, simulate);
 
         // Quickly return if the to-be-inserted ingredient was already empty
         if (matcher.isEmpty(ingredient)) {

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientChannelAdapterWrapperSlotted.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientChannelAdapterWrapperSlotted.java
@@ -141,9 +141,8 @@ public class IngredientChannelAdapterWrapperSlotted<T, M> implements IIngredient
     @Override
     public T insert(int slotAbsolute, @Nonnull T ingredient, boolean simulate) {
         // First run the ingredient instance through the pre-consumers.
-        for (IIngredientChannelInsertPreConsumer<T> insertPreConsumer : this.channel.getNetwork().getInsertPreConsumers()) {
-            ingredient = insertPreConsumer.insert(this.channel.getChannel(), ingredient, simulate);
-        }
+        ingredient = IIngredientChannelInsertPreConsumer.applyAll(this.channel.getNetwork().getInsertPreConsumers(),
+                getComponent().getMatcher(), this.channel.getChannel(), ingredient, ingredient, simulate);
 
         Triple<IIngredientComponentStorage<T, M>, Integer, PartPos> storageAndSlot = getStorageAndRelativeSlot(slotAbsolute);
         IIngredientComponentStorage<T, M> storage = storageAndSlot.getLeft();

--- a/src/test/java/org/cyclops/integrateddynamics/core/network/TestIngredientChannelInsertPreConsumer.java
+++ b/src/test/java/org/cyclops/integrateddynamics/core/network/TestIngredientChannelInsertPreConsumer.java
@@ -1,0 +1,237 @@
+package org.cyclops.integrateddynamics.core.network;
+
+import com.google.common.collect.Lists;
+import net.minecraft.network.chat.MutableComponent;
+import org.cyclops.commoncapabilities.api.ingredient.IIngredientMatcher;
+import org.junit.Test;
+
+
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for how insert pre-consumers are chained on an ingredient channel.
+ *
+ * Instances are plain longs here, where the value is the quantity.
+ *
+ * @author rubensworks
+ */
+public class TestIngredientChannelInsertPreConsumer {
+
+    private static final IIngredientMatcher<Long, Boolean> MATCHER = new LongMatcher();
+
+    @Test
+    public void testClaimingPreConsumersDoNotShareTheSameInstance() {
+        ClaimingPreConsumer first = new ClaimingPreConsumer(1);
+        ClaimingPreConsumer second = new ClaimingPreConsumer(1);
+
+        long remaining = IIngredientChannelInsertPreConsumer.applyAll(
+                Lists.newArrayList(first, second), MATCHER, 0, 1L, 1L, false);
+
+        assertEquals("only the first pre-consumer claims the instance", 1L, first.claimed);
+        assertEquals("the second pre-consumer sees nothing left to claim", 0L, second.claimed);
+        assertEquals("the instance is still inserted into the network", 1L, remaining);
+    }
+
+    @Test
+    public void testClaimingPreConsumersSplitTheSameInstance() {
+        ClaimingPreConsumer first = new ClaimingPreConsumer(2);
+        ClaimingPreConsumer second = new ClaimingPreConsumer(5);
+
+        long remaining = IIngredientChannelInsertPreConsumer.applyAll(
+                Lists.newArrayList(first, second), MATCHER, 0, 3L, 3L, false);
+
+        assertEquals(2L, first.claimed);
+        assertEquals(1L, second.claimed);
+        assertEquals(3L, remaining);
+    }
+
+    @Test
+    public void testQuantityClaimedBeforeTheChannelIsNotClaimedAgain() {
+        ClaimingPreConsumer preConsumer = new ClaimingPreConsumer(5);
+
+        long remaining = IIngredientChannelInsertPreConsumer.applyAll(
+                Lists.newArrayList(preConsumer), MATCHER, 0, 3L, 1L, false);
+
+        assertEquals("only the part that was not claimed yet can be claimed", 1L, preConsumer.claimed);
+        assertEquals(3L, remaining);
+    }
+
+    @Test
+    public void testTakenQuantityCanNotBeClaimedAgain() {
+        ConsumingPreConsumer first = new ConsumingPreConsumer(2);
+        ClaimingPreConsumer second = new ClaimingPreConsumer(5);
+
+        long remaining = IIngredientChannelInsertPreConsumer.applyAll(
+                Lists.newArrayList(first, second), MATCHER, 0, 3L, 3L, false);
+
+        assertEquals("what is taken away can not be claimed", 1L, second.claimed);
+        assertEquals(1L, remaining);
+    }
+
+    @Test
+    public void testDeprecatedPreConsumersCanNotBeOverClaimed() {
+        DeprecatedConsumingPreConsumer first = new DeprecatedConsumingPreConsumer(2);
+        ClaimingPreConsumer second = new ClaimingPreConsumer(5);
+
+        long remaining = IIngredientChannelInsertPreConsumer.applyAll(
+                Lists.newArrayList(first, second), MATCHER, 0, 3L, 3L, false);
+
+        assertEquals("the unclaimed quantity never exceeds the remaining quantity", 1L, second.claimed);
+        assertEquals(1L, remaining);
+    }
+
+    /**
+     * Claims the instance for itself without taking it away, like a pre-consumer that awaits an output.
+     */
+    private static class ClaimingPreConsumer implements IIngredientChannelInsertPreConsumer<Long> {
+
+        private final long capacity;
+        private long claimed;
+
+        public ClaimingPreConsumer(long capacity) {
+            this.capacity = capacity;
+        }
+
+        @Override
+        public Result<Long> insert(int channel, Long ingredient, Long unclaimed, boolean simulate) {
+            long claiming = Math.min(this.capacity - this.claimed, unclaimed);
+            this.claimed += claiming;
+            return new Result<>(ingredient, unclaimed - claiming);
+        }
+    }
+
+    /**
+     * Takes part of the instance away, so that it is not inserted into the network.
+     */
+    private static class ConsumingPreConsumer implements IIngredientChannelInsertPreConsumer<Long> {
+
+        private final long capacity;
+
+        public ConsumingPreConsumer(long capacity) {
+            this.capacity = capacity;
+        }
+
+        @Override
+        public Result<Long> insert(int channel, Long ingredient, Long unclaimed, boolean simulate) {
+            long taken = Math.min(this.capacity, unclaimed);
+            return new Result<>(ingredient - taken, unclaimed - taken);
+        }
+    }
+
+    /**
+     * Takes part of the instance away through the deprecated api, which is unaware of claiming.
+     */
+    private static class DeprecatedConsumingPreConsumer implements IIngredientChannelInsertPreConsumer<Long> {
+
+        private final long capacity;
+
+        public DeprecatedConsumingPreConsumer(long capacity) {
+            this.capacity = capacity;
+        }
+
+        @Override
+        public Long insert(int channel, Long ingredient, boolean simulate) {
+            return ingredient - Math.min(this.capacity, ingredient);
+        }
+    }
+
+    private static class LongMatcher implements IIngredientMatcher<Long, Boolean> {
+
+        @Override
+        public boolean isInstance(Object object) {
+            return object instanceof Long;
+        }
+
+        @Override
+        public Boolean getAnyMatchCondition() {
+            return false;
+        }
+
+        @Override
+        public Boolean getExactMatchCondition() {
+            return true;
+        }
+
+        @Override
+        public Boolean getExactMatchNoQuantityCondition() {
+            return false;
+        }
+
+        @Override
+        public Boolean withCondition(Boolean matchCondition, Boolean with) {
+            return matchCondition || with;
+        }
+
+        @Override
+        public Boolean withoutCondition(Boolean matchCondition, Boolean without) {
+            return matchCondition == without ? false : matchCondition;
+        }
+
+        @Override
+        public boolean hasCondition(Boolean matchCondition, Boolean searchCondition) {
+            return matchCondition == searchCondition;
+        }
+
+        @Override
+        public boolean matches(Long a, Long b, Boolean matchCondition) {
+            return !matchCondition || a.longValue() == b.longValue();
+        }
+
+        @Override
+        public Long getEmptyInstance() {
+            return 0L;
+        }
+
+        @Override
+        public int hash(Long instance) {
+            return instance.hashCode();
+        }
+
+        @Override
+        public Long copy(Long instance) {
+            return instance;
+        }
+
+        @Override
+        public long getQuantity(Long instance) {
+            return instance;
+        }
+
+        @Override
+        public Long withQuantity(Long instance, long quantity) {
+            return quantity;
+        }
+
+        @Override
+        public long getMaximumQuantity() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public int conditionCompare(Boolean a, Boolean b) {
+            return Boolean.compare(a, b);
+        }
+
+        @Override
+        public String localize(Long instance) {
+            return toString(instance);
+        }
+
+        @Override
+        public MutableComponent getDisplayName(Long instance) {
+            return null;
+        }
+
+        @Override
+        public String toString(Long instance) {
+            return String.valueOf(instance);
+        }
+
+        @Override
+        public int compare(Long a, Long b) {
+            return Long.compare(a, b);
+        }
+    }
+
+}


### PR DESCRIPTION
Backport of #1720 to `master-1.20-lts`. Companion of CyclopsMC/IntegratedCrafting#227, which needs this. On its own this changes no behaviour.

The commit cherry-picked cleanly — the pre-consumer interface and both call sites are identical to the ones on `master-1.21-lts`.

## Problem

Every insert pre-consumer registered on an ingredient channel observes the same insertion, chained by the remaining instance. That works for a pre-consumer that *takes part of the insertion away*, since what it takes is gone from the instance it passes on. It does not work for one that *claims* part of the insertion without taking it away, because the instance it passes on is unchanged, so the next pre-consumer claims that very same instance too.

Integrated Crafting's crafting job output observer is exactly the second kind, so with several crafting interfaces running parallel jobs for the same output, one produced item resolved the pending output of every one of those jobs at once.

## Change

`IIngredientChannelInsertPreConsumer` now also carries the *unclaimed* part of an insertion, next to the remaining part:

| Action | `remaining` | `unclaimed` |
|---|---|---|
| Takes part of the insertion away | ↓ | ↓ |
| Only claims part of it (the item still has to be stored) | — | ↓ |

- `insert(channel, ingredient, unclaimed, simulate)` returns a `Result(remaining, unclaimed)`. Only the unclaimed part may be claimed, so one insertion is never claimed twice.
- The single-instance method is deprecated; its default keeps the old behaviour for pre-consumers that have not migrated, and `applyAll` clamps the unclaimed part to the remaining part so such a pre-consumer can not cause over-claiming.
- `applyAll` holds the chaining that was duplicated in `IngredientChannelAdapter` and `IngredientChannelAdapterWrapperSlotted`.
- `INetworkIngredientsChannel` additionally accepts an insertion of which a part was already claimed before it reached the channel.

## Testing

- `TestIngredientChannelInsertPreConsumer` covers the chaining, ported unchanged.
- `./gradlew build` passes (JDK 17).

Game tests are not run here: they only exist on 1.21 and above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EypmxuPjaJ4cFGh2DvZYbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EypmxuPjaJ4cFGh2DvZYbf)_