### PR TITLE
Hash a prototype once per index position update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,6 @@ org.gradle.configuration-cache=true
 org.gradle.configureondemand=true
 
 # Dependencies
-cyclopscore_version=1.29.5-1012
+cyclopscore_version=1.30.4-1135
 integrateddynamicscompat_version=26.1.2-neoforge:1.0.0-185
 commoncapabilities_version=2.11.4-344

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientPositionsIndex.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientPositionsIndex.java
@@ -138,11 +138,10 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
         }
 
         T prototype = getPrototype(instance);
-        ObjectOpenHashSet<PartPos> set = positionsMap.get(prototype);
-        if (set == null) {
-            set = new ObjectOpenHashSet<>();
-            positionsMap.put(prototype, set);
-        }
+        // Computed in one call so the prototype is hashed once rather than once to look it up and
+        // once to store it. Hashing a prototype dominates this method for component-bearing types.
+        ObjectOpenHashSet<PartPos> set = positionsMap.compute(prototype,
+                (key, existing) -> existing == null ? new ObjectOpenHashSet<>() : existing);
 
         if (set.add(pos.getPartPos())) {
             Object2IntOpenHashMap<PartPos> positions = this.prioritizedPositions.get(priority);
@@ -180,8 +179,12 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
         IIngredientMapMutable<T, M, ObjectOpenHashSet<PartPos>> positionsMap = this.prioritizedPositionsMap.get(priority);
         if (positionsMap != null) {
             T prototype = getPrototype(instance);
-            ObjectOpenHashSet<PartPos> set = positionsMap.get(prototype);
-            if (set != null) {
+            // As in addPosition, one call so the prototype is hashed once rather than once to look
+            // it up and once to drop it. Returning null from the remapping drops the entry.
+            positionsMap.compute(prototype, (key, set) -> {
+                if (set == null) {
+                    return null;
+                }
                 if (set.remove(pos.getPartPos())) {
                     Object2IntOpenHashMap<PartPos> positions = this.prioritizedPositions.get(priority);
                     // addTo returns the value before the addition, so at most one instance is left in this position
@@ -192,12 +195,10 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
                         }
                     }
                 }
-                if (set.isEmpty()) {
-                    positionsMap.remove(prototype);
-                    if (positionsMap.isEmpty()) {
-                        this.prioritizedPositionsMap.remove(priority);
-                    }
-                }
+                return set.isEmpty() ? null : set;
+            });
+            if (positionsMap.isEmpty()) {
+                this.prioritizedPositionsMap.remove(priority);
             }
         }
     }


### PR DESCRIPTION
`IngredientPositionsIndex.addPosition` and `removePosition` each look a prototype up and then store or drop it. Every ingredient map call builds its own key wrapper, so the prototype was hashed twice for one update. For ItemStack that hash walks a data component map, and `PositionedAddonsNetworkIngredients.applyChangesToChannel` runs each change twice over, once for its own channel and once for the wildcard channel, so it multiplies.

Both now use the `compute` method added in CyclopsMC/CyclopsCore#239, which hashes once.

Behaviour is unchanged. `removePosition` still drops the entry when its position set runs empty and still drops the priority level when the map runs empty; the only difference is that the level check now runs unconditionally, which can only be true when an entry was actually dropped.

## Dependency is now satisfied

CyclopsMC/CyclopsCore#239 is merged and released. `cyclopscore_version` is bumped to `1.30.4-1135` in this PR, which is the CyclopsCore build carrying both #238 and #239 (run 1135, all deploy steps green).

Verified rather than assumed:

- The artifact is live on GitHub Packages. `cyclopscore-26.1.2-neoforge:1.30.4-1135` returns 200; a made-up neighbouring version returns 404, so the check distinguishes.
- The local Maven copy was deleted and the build re-run with `--refresh-dependencies`, so resolution had to go to GitHub Packages. It did, and `./gradlew build` passed.
- `./gradlew runGameTestServer` against that resolved dependency: all 964 required tests pass.

The branch is rebased onto current `master-26-lts`, so it carries the benchmarks from #1722.

## Numbers

`PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew runGameTestServer`, ms per operation, medians of six runs each, alternating between the two configurations within one session so session drift falls on both equally. Both sides carry CyclopsMC/CyclopsCore#238, since this only pays off once hashing costs something.

These were measured before the release, against a locally built CyclopsCore carrying #239. They were **not** re-measured against `1.30.4-1135`; that build is the same code, and the run after the bump was a correctness check, not a benchmark.

| benchmark | without compute | with compute | factor |
|---|---:|---:|---|
| index_modification_single_item | 0.001162 | 0.000688 | **41% faster** |
| index_modification_few_items | 0.001084 | 0.000726 | **33% faster** |
| index_modification_heavy_components | 0.002510 | 0.002077 | **17% faster** |
| index_modification_mixed | 0.000713 | 0.000667 | 6% faster |
| index_modification_plain | 0.000530 | 0.000507 | 4% faster |
| index_modification | 0.001246 | 0.001381 | 11% slower |

Lookups land within 10% either way with no consistent direction, as expected: they do not read-then-write.

The win is concentrated where hashing dominates a modification, meaning many component variants of one item or a large component payload. On the realistic `mixed` shape it is 6% with overlapping distributions, because CyclopsMC/CyclopsCore#238 already skips the component hash for stacks carrying no patch and most instances there carry none. The spread-shape `index_modification` row runs first in the sequence and absorbs warm-up; its two distributions overlap almost completely, so I would not read a regression into it and cannot rule one out either.

No changelog entry, as requested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxjin31W1Lmq5XK1CCe84v)_