### PR TITLE
Hash a prototype once per index position update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,6 @@ org.gradle.daemon=false
 org.gradle.caching=true
 
 # Dependencies
-cyclopscore_version=1.26.0-752
+cyclopscore_version=1.29.4-1127
 integrateddynamicscompat_version=1.0.0-184
 commoncapabilities_version=2.9.11-236

--- a/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientPositionsIndex.java
+++ b/src/main/java/org/cyclops/integrateddynamics/core/network/IngredientPositionsIndex.java
@@ -138,11 +138,10 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
         }
 
         T prototype = getPrototype(instance);
-        ObjectOpenHashSet<PartPos> set = positionsMap.get(prototype);
-        if (set == null) {
-            set = new ObjectOpenHashSet<>();
-            positionsMap.put(prototype, set);
-        }
+        // Computed in one call so the prototype is hashed once rather than once to look it up and
+        // once to store it. Hashing a prototype dominates this method for component-bearing types.
+        ObjectOpenHashSet<PartPos> set = positionsMap.compute(prototype,
+                (key, existing) -> existing == null ? new ObjectOpenHashSet<>() : existing);
 
         if (set.add(pos.getPartPos())) {
             Object2IntOpenHashMap<PartPos> positions = this.prioritizedPositions.get(priority);
@@ -180,8 +179,12 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
         IIngredientMapMutable<T, M, ObjectOpenHashSet<PartPos>> positionsMap = this.prioritizedPositionsMap.get(priority);
         if (positionsMap != null) {
             T prototype = getPrototype(instance);
-            ObjectOpenHashSet<PartPos> set = positionsMap.get(prototype);
-            if (set != null) {
+            // As in addPosition, one call so the prototype is hashed once rather than once to look
+            // it up and once to drop it. Returning null from the remapping drops the entry.
+            positionsMap.compute(prototype, (key, set) -> {
+                if (set == null) {
+                    return null;
+                }
                 if (set.remove(pos.getPartPos())) {
                     Object2IntOpenHashMap<PartPos> positions = this.prioritizedPositions.get(priority);
                     // addTo returns the value before the addition, so at most one instance is left in this position
@@ -192,12 +195,10 @@ public class IngredientPositionsIndex<T, M> implements IIngredientPositionsIndex
                         }
                     }
                 }
-                if (set.isEmpty()) {
-                    positionsMap.remove(prototype);
-                    if (positionsMap.isEmpty()) {
-                        this.prioritizedPositionsMap.remove(priority);
-                    }
-                }
+                return set.isEmpty() ? null : set;
+            });
+            if (positionsMap.isEmpty()) {
+                this.prioritizedPositionsMap.remove(priority);
             }
         }
     }


### PR DESCRIPTION
`IngredientPositionsIndex.addPosition` and `removePosition` each look a prototype up and then store or drop it. Every ingredient map call builds its own key wrapper, so the prototype was hashed twice for one update. For ItemStack that hash walks a data component map, and `PositionedAddonsNetworkIngredients.applyChangesToChannel` runs each change twice over, once for its own channel and once for the wildcard channel, so it multiplies.

Both now use the `compute` method added in CyclopsMC/CyclopsCore#241, which hashes once.

Behaviour is unchanged. `removePosition` still drops the entry when its position set runs empty and still drops the priority level when the map runs empty; the only difference is that the level check now runs unconditionally, which can only be true when an entry was actually dropped.

## Dependency, now satisfied

CyclopsMC/CyclopsCore#241 is merged and published as **1.29.4-1127** (CI run 1127, Maven deploy step succeeded). This branch bumps `cyclopscore_version` from `1.26.0-752` to `1.29.4-1127` in a separate commit, so it compiles on its own and CI should be green.

That is a large jump, 375 build numbers, and it pulls in every CyclopsCore change since. It is required for this PR to build, but it is arguably a separate concern from the change itself; if you would rather bump the pin on `master-1.21-lts` directly and rebase this, drop that commit and I will rework it.

I verified the jump locally rather than assuming it: the merged `master-1.21-lts` CyclopsCore was published to a local Maven repo as exactly `1.29.4-1127`, and `./gradlew build` passes against it on this branch. Rebased onto current `master-1.21-lts`, so the benchmarks from #1727 are present.

## Numbers

**These come from 26.1, not from 1.21.** `IngredientPositionsIndex.java` is byte identical between `master-1.21-lts` and `master-26-lts`, so it is the same patch, but I did not re-run the benchmarks here. A paired set on this branch is a couple of hours, since each full run takes about 33 minutes. Happy to do it now that the dependency is in place, if you want the numbers before merging.

ms per operation, medians of six runs each, alternating between the two configurations within one session. Both sides carry the CyclopsCore hash and classifier fixes.

| benchmark | without compute | with compute | factor |
|---|---:|---:|---|
| index_modification_single_item | 0.001162 | 0.000688 | **41% faster** |
| index_modification_few_items | 0.001084 | 0.000726 | **33% faster** |
| index_modification_heavy_components | 0.002510 | 0.002077 | **17% faster** |
| index_modification_mixed | 0.000713 | 0.000667 | 6% faster |
| index_modification_plain | 0.000530 | 0.000507 | 4% faster |
| index_modification | 0.001246 | 0.001381 | 11% slower |

Lookups land within 10% either way with no consistent direction, as expected: they do not read-then-write.

The win is concentrated where hashing dominates a modification. On the realistic mixed shape it is 6% with overlapping distributions, because the CyclopsCore hash fix already skips the component hash for stacks carrying no patch. The spread-shape row runs first in the sequence and absorbs warm-up; its two distributions overlap almost completely, so I would not read a regression into it and cannot rule one out either.

On 1.21 the hash fix makes modifications faster rather than slower, unlike on 26.1, because the baseline collides much harder here. The cost this change reduces is therefore a smaller share of the total on 1.21, so the benefit here is probably smaller than the table suggests.

## Relationship to the 26.1 branch

CyclopsMC/IntegratedDynamics#1725 is the same change against `master-26-lts` and stays open. Merge whichever suits your upmerge direction.

No changelog entry, as requested.