### PR TITLE
Say nothing about a configuration that the Wrench mode can not paste

### DIFF
--- a/src/main/java/org/cyclops/integrateddynamics/item/ItemWrench.java
+++ b/src/main/java/org/cyclops/integrateddynamics/item/ItemWrench.java
@@ -178,6 +178,10 @@ public class ItemWrench extends Item {
             PartConfigSnapshot.fromNBT(context.registries(), configTag).ifPresent(snapshot -> {
                 // Only the sections that the current mode pastes are relevant
                 Set<PartConfigSection> sections = Sets.intersection(snapshot.getSections(), mode.getConfigSections());
+                if (sections.isEmpty()) {
+                    // This mode has nothing to paste from this configuration, so it has nothing to say about it
+                    return;
+                }
                 list.add(Component.translatable("item.integrateddynamics.wrench.mode.config.source",
                         Component.translatable(getSourcePartTypeName(snapshot))).withStyle(ChatFormatting.GRAY));
                 list.add(Component.translatable("item.integrateddynamics.wrench.mode.config.sections",


### PR DESCRIPTION
Small follow-up to #1721, found while testing the Integrated Tunnels side in a dev client.

A Wrench holding a configuration keeps it when you switch modes. When the mode pastes a section that the configuration has nothing for, the tooltip still printed the source part and an `Includes: ` line with an empty list after it. For example a Wrench that copied part settings, switched to Copy Aspect:

```
Wrench
Mode: Copy Aspect
Copied from: Item Interface
Includes:
```

Those two lines are now left out entirely when the current mode has nothing to paste from what is stored, so the tooltip is just the mode line. Right-clicking a part in that state already said `No matching configuration was copied into this Wrench yet`, which stays as it was.

Verified in a dev client, in both directions: Copy Settings on the same Wrench still lists `Copied from: Item Interface` and `Includes: part settings`, Copy Aspect now shows neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBAgcFp6jWcYRWz9N8h7AF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBAgcFp6jWcYRWz9N8h7AF)_